### PR TITLE
Devel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ target/
 nbactions.xml
 nb-configuration.xml
 /bin/
+.project
+.classpath
+.settings/

--- a/torod/db-wrappers/postgresql/src/main/java/com/torodb/torod/db/postgresql/PostgresqlDbConnection.java
+++ b/torod/db-wrappers/postgresql/src/main/java/com/torodb/torod/db/postgresql/PostgresqlDbConnection.java
@@ -365,19 +365,18 @@ class PostgresqlDbConnection extends AbstractSqlDbConnection {
         if (field.getConverter() != null) {
             SubdocValueConverter arrayConverter
                     = ValueToJooqConverterProvider.getConverter(BasicType.ARRAY);
+            if (field.getConverter().getClass().equals(arrayConverter.getClass())) {
+            	return "jsonb";
+            }
             SubdocValueConverter twelveBytesConverter
                     = ValueToJooqConverterProvider.getConverter(BasicType.TWELVE_BYTES);
+            if (field.getConverter().getClass().equals(twelveBytesConverter.getClass())) {
+            	return "torodb.twelve_bytes";
+            }
             SubdocValueConverter patternConverter
                     = ValueToJooqConverterProvider.getConverter(BasicType.PATTERN);
-
-            if (field.getConverter().getClass().equals(arrayConverter.getClass())) {
-                return "jsonb";
-            }
-            if (field.getConverter().getClass().equals(twelveBytesConverter.getClass())) {
-                return "twelve_bytes";
-            }
             if (field.getConverter().getClass().equals(patternConverter.getClass())) {
-                return "torodb_pattern";
+                return "torodb.torodb_pattern";
             }
         }
         return field.getDataType().getTypeName(conf);

--- a/torod/db-wrappers/postgresql/src/main/java/com/torodb/torod/db/postgresql/meta/Routines.java
+++ b/torod/db-wrappers/postgresql/src/main/java/com/torodb/torod/db/postgresql/meta/Routines.java
@@ -40,7 +40,7 @@ import org.jooq.Configuration;
 public class Routines {
 
     /**
-     * Call <code>public.first_free_value_type_id</code>
+     * Call <code>torodb.first_free_value_type_id</code>
      * @param configuration
      * @param colSchema
      * @return 
@@ -54,7 +54,7 @@ public class Routines {
     }
 
     /**
-     * Call <code>public.reserve_value_type_id</code>
+     * Call <code>torodb.reserve_value_type_id</code>
      * @param configuration
      * @param colSchema 
      * @param increment

--- a/torod/db-wrappers/postgresql/src/main/java/com/torodb/torod/db/postgresql/meta/TorodbMeta.java
+++ b/torod/db-wrappers/postgresql/src/main/java/com/torodb/torod/db/postgresql/meta/TorodbMeta.java
@@ -277,7 +277,7 @@ public class TorodbMeta {
     ) throws SQLException {
         ResultSet procedures = null;
         try {
-            procedures = jdbcMeta.getProcedures(null, "", procedureName);
+            procedures = jdbcMeta.getProcedures(null, "torodb", procedureName);
             
             return procedures.next();
         } finally {

--- a/torod/db-wrappers/postgresql/src/main/java/com/torodb/torod/db/postgresql/meta/routines/FirstFreeDocId.java
+++ b/torod/db-wrappers/postgresql/src/main/java/com/torodb/torod/db/postgresql/meta/routines/FirstFreeDocId.java
@@ -31,12 +31,12 @@ public class FirstFreeDocId extends org.jooq.impl.AbstractRoutine<java.lang.Inte
 	private static final long serialVersionUID = -16798621;
 
 	/**
-	 * The parameter <code>public.first_free_value_type_id.RETURN_VALUE</code>.
+	 * The parameter <code>torodb.first_free_value_type_id.RETURN_VALUE</code>.
 	 */
 	public static final org.jooq.Parameter<java.lang.Integer> RETURN_VALUE = createParameter("RETURN_VALUE", org.jooq.impl.SQLDataType.INTEGER);
 
 	/**
-	 * The parameter <code>public.first_free_value_type_id.col_schema</code>.
+	 * The parameter <code>torodb.first_free_value_type_id.col_schema</code>.
 	 */
 	public static final org.jooq.Parameter<java.lang.String> COL_SCHEMA = createParameter("col_schema", org.jooq.impl.SQLDataType.VARCHAR);
 
@@ -44,7 +44,7 @@ public class FirstFreeDocId extends org.jooq.impl.AbstractRoutine<java.lang.Inte
 	 * Create a new routine call instance
 	 */
 	public FirstFreeDocId() {
-		super("first_free_doc_id", com.torodb.torod.db.postgresql.meta.PublicSchema.PUBLIC, org.jooq.impl.SQLDataType.INTEGER);
+		super("first_free_doc_id", com.torodb.torod.db.postgresql.meta.TorodbSchema.TORODB, org.jooq.impl.SQLDataType.INTEGER);
 
 		setReturnParameter(RETURN_VALUE);
 		addInParameter(COL_SCHEMA);

--- a/torod/db-wrappers/postgresql/src/main/java/com/torodb/torod/db/postgresql/meta/routines/ReserveDocIds.java
+++ b/torod/db-wrappers/postgresql/src/main/java/com/torodb/torod/db/postgresql/meta/routines/ReserveDocIds.java
@@ -33,17 +33,17 @@ public class ReserveDocIds extends org.jooq.impl.AbstractRoutine<java.lang.Integ
 	private static final long serialVersionUID = -566845238;
 
 	/**
-	 * The parameter <code>public.reserve_value_type_id.RETURN_VALUE</code>.
+	 * The parameter <code>torodb.reserve_value_type_id.RETURN_VALUE</code>.
 	 */
 	public static final org.jooq.Parameter<java.lang.Integer> RETURN_VALUE = createParameter("RETURN_VALUE", org.jooq.impl.SQLDataType.INTEGER);
 
 	/**
-	 * The parameter <code>public.reserve_value_type_id.col_schema</code>.
+	 * The parameter <code>torodb.reserve_value_type_id.col_schema</code>.
 	 */
 	public static final org.jooq.Parameter<java.lang.String> COL_SCHEMA = createParameter("col_schema", org.jooq.impl.SQLDataType.VARCHAR);
 
 	/**
-	 * The parameter <code>public.reserve_value_type_id.increment</code>.
+	 * The parameter <code>torodb.reserve_value_type_id.increment</code>.
 	 */
 	public static final org.jooq.Parameter<java.lang.Integer> INCREMENT = createParameter("increment", org.jooq.impl.SQLDataType.INTEGER);
 
@@ -51,7 +51,7 @@ public class ReserveDocIds extends org.jooq.impl.AbstractRoutine<java.lang.Integ
 	 * Create a new routine call instance
 	 */
 	public ReserveDocIds() {
-		super("reserve_doc_ids", com.torodb.torod.db.postgresql.meta.PublicSchema.PUBLIC, org.jooq.impl.SQLDataType.INTEGER);
+		super("reserve_doc_ids", com.torodb.torod.db.postgresql.meta.TorodbSchema.TORODB, org.jooq.impl.SQLDataType.INTEGER);
 
 		setReturnParameter(RETURN_VALUE);
 		addInParameter(COL_SCHEMA);

--- a/torod/db-wrappers/postgresql/src/main/java/com/torodb/torod/db/postgresql/udt/TwelveBytesUDT.java
+++ b/torod/db-wrappers/postgresql/src/main/java/com/torodb/torod/db/postgresql/udt/TwelveBytesUDT.java
@@ -20,8 +20,9 @@
 
 package com.torodb.torod.db.postgresql.udt;
 
-import com.torodb.torod.db.postgresql.meta.PublicSchema;
+import com.torodb.torod.db.postgresql.meta.TorodbSchema;
 import com.torodb.torod.db.postgresql.udt.records.TwelveBytesRecord;
+
 import org.jooq.impl.UDTImpl;
 
 /**
@@ -35,7 +36,7 @@ public class TwelveBytesUDT extends UDTImpl<TwelveBytesRecord> {
 	private static final long serialVersionUID = -552117608;
 
 	/**
-	 * The singleton instance of <code>public.twelve_bytes</code>
+	 * The singleton instance of <code>torodb.twelve_bytes</code>
 	 */
 	public static final TwelveBytesUDT TWELVE_BYTES = new TwelveBytesUDT();
 
@@ -48,17 +49,17 @@ public class TwelveBytesUDT extends UDTImpl<TwelveBytesRecord> {
 	}
 
 	/**
-	 * The attribute <code>public.twelve_bytes.upper</code>.
+	 * The attribute <code>torodb.twelve_bytes.upper</code>.
 	 */
 	public static final org.jooq.UDTField<TwelveBytesRecord, Integer> UPPPER = createField("upper", org.jooq.impl.SQLDataType.INTEGER, TWELVE_BYTES);
 
 	/**
-	 * The attribute <code>public.twelve_bytes.middle</code>.
+	 * The attribute <code>torodb.twelve_bytes.middle</code>.
 	 */
 	public static final org.jooq.UDTField<TwelveBytesRecord, Integer> MIDDLE = createField("middle", org.jooq.impl.SQLDataType.INTEGER, TWELVE_BYTES);
 
 	/**
-	 * The attribute <code>public.twelve_bytes.lower</code>.
+	 * The attribute <code>torodb.twelve_bytes.lower</code>.
 	 */
 	public static final org.jooq.UDTField<TwelveBytesRecord, Integer> LOWER = createField("lower", org.jooq.impl.SQLDataType.INTEGER, TWELVE_BYTES);
 
@@ -66,7 +67,7 @@ public class TwelveBytesUDT extends UDTImpl<TwelveBytesRecord> {
 	 * No further instances allowed
 	 */
 	private TwelveBytesUDT() {
-		super("twelve_bytes", PublicSchema.PUBLIC);
+		super("twelve_bytes", TorodbSchema.TORODB);
 
 		// Initialise data type
 		getDataType();

--- a/torod/db-wrappers/postgresql/src/main/java/com/torodb/torod/db/postgresql/udt/records/TwelveBytesRecord.java
+++ b/torod/db-wrappers/postgresql/src/main/java/com/torodb/torod/db/postgresql/udt/records/TwelveBytesRecord.java
@@ -38,42 +38,42 @@ public class TwelveBytesRecord extends UDTRecordImpl<TwelveBytesRecord> implemen
 	private static final long serialVersionUID = -103355438;
 
 	/**
-	 * Setter for <code>public.twelve_bytes.upper</code>.
+	 * Setter for <code>torodb.twelve_bytes.upper</code>.
 	 */
 	public void setUpper(Integer value) {
 		setValue(0, value);
 	}
 
 	/**
-	 * Getter for <code>public.twelve_bytes.upper</code>.
+	 * Getter for <code>torodb.twelve_bytes.upper</code>.
 	 */
 	public Integer getUpper() {
 		return (Integer) getValue(0);
 	}
 
 	/**
-	 * Setter for <code>public.twelve_bytes.middle</code>.
+	 * Setter for <code>torodb.twelve_bytes.middle</code>.
 	 */
 	public void setMiddle(Integer value) {
 		setValue(1, value);
 	}
 
 	/**
-	 * Getter for <code>public.twelve_bytes.middle</code>.
+	 * Getter for <code>torodb.twelve_bytes.middle</code>.
 	 */
 	public Integer getMiddle() {
 		return (Integer) getValue(1);
 	}
 
 	/**
-	 * Setter for <code>public.twelve_bytes.lower</code>.
+	 * Setter for <code>torodb.twelve_bytes.lower</code>.
 	 */
 	public void setLower(Integer value) {
 		setValue(2, value);
 	}
 
 	/**
-	 * Getter for <code>public.twelve_bytes.lower</code>.
+	 * Getter for <code>torodb.twelve_bytes.lower</code>.
 	 */
 	public Integer getLower() {
 		return (Integer) getValue(2);

--- a/torod/db-wrappers/postgresql/src/main/resources/sql/find_doc.sql
+++ b/torod/db-wrappers/postgresql/src/main/resources/sql/find_doc.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION find_doc(col_schema varchar, did integer, tables integer[])
+CREATE OR REPLACE FUNCTION torodb.find_doc(col_schema varchar, did integer, tables integer[])
 RETURNS SETOF find_doc_type AS $$
 DECLARE
     t integer;

--- a/torod/db-wrappers/postgresql/src/main/resources/sql/find_doc.sql
+++ b/torod/db-wrappers/postgresql/src/main/resources/sql/find_doc.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE FUNCTION torodb.find_doc(col_schema varchar, did integer, tables integer[])
-RETURNS SETOF find_doc_type AS $$
+RETURNS SETOF torodb.find_doc_type AS $$
 DECLARE
     t integer;
     i integer := 0;

--- a/torod/db-wrappers/postgresql/src/main/resources/sql/find_doc_type.sql
+++ b/torod/db-wrappers/postgresql/src/main/resources/sql/find_doc_type.sql
@@ -1,1 +1,1 @@
-CREATE TYPE find_doc_type AS (did int, typeid int, index int, _json text);
+CREATE TYPE torodb.find_doc_type AS (did int, typeid int, index int, _json text);

--- a/torod/db-wrappers/postgresql/src/main/resources/sql/find_docs.sql
+++ b/torod/db-wrappers/postgresql/src/main/resources/sql/find_docs.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE FUNCTION torodb.find_docs(col_schema varchar, dids int[], tables int[])
-RETURNS SETOF find_doc_type AS $$
+RETURNS SETOF torodb.find_doc_type AS $$
 DECLARE
     docid integer;
 BEGIN

--- a/torod/db-wrappers/postgresql/src/main/resources/sql/find_docs.sql
+++ b/torod/db-wrappers/postgresql/src/main/resources/sql/find_docs.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION find_docs(col_schema varchar, dids int[], tables int[])
+CREATE OR REPLACE FUNCTION torodb.find_docs(col_schema varchar, dids int[], tables int[])
 RETURNS SETOF find_doc_type AS $$
 DECLARE
     docid integer;

--- a/torod/db-wrappers/postgresql/src/main/resources/sql/first_free_doc_id.sql
+++ b/torod/db-wrappers/postgresql/src/main/resources/sql/first_free_doc_id.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION first_free_doc_id(col_schema varchar)
+CREATE OR REPLACE FUNCTION torodb.first_free_doc_id(col_schema varchar)
 RETURNS integer AS $$
 DECLARE
     seq_name varchar := '"' || col_schema || '".root_seq';

--- a/torod/db-wrappers/postgresql/src/main/resources/sql/json_cast.sql
+++ b/torod/db-wrappers/postgresql/src/main/resources/sql/json_cast.sql
@@ -1,1 +1,1 @@
-CREATE CAST (varchar AS jsonb) WITH FUNCTION varchar_to_jsonb(varchar) AS IMPLICIT;
+CREATE CAST (varchar AS jsonb) WITH FUNCTION torodb.varchar_to_jsonb(varchar) AS IMPLICIT;

--- a/torod/db-wrappers/postgresql/src/main/resources/sql/reserve_doc_ids.sql
+++ b/torod/db-wrappers/postgresql/src/main/resources/sql/reserve_doc_ids.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE FUNCTION reserve_doc_ids(col_schema varchar, increment integer)
+CREATE OR REPLACE FUNCTION torodb.reserve_doc_ids(col_schema varchar, increment integer)
 RETURNS integer AS $$
 DECLARE
     seq_name varchar := '"' || col_schema || '".root_seq';

--- a/torod/db-wrappers/postgresql/src/main/resources/sql/torodb_pattern_type.sql
+++ b/torod/db-wrappers/postgresql/src/main/resources/sql/torodb_pattern_type.sql
@@ -1,1 +1,1 @@
-CREATE DOMAIN torodb_pattern AS varchar;
+CREATE DOMAIN torodb.torodb_pattern AS varchar;

--- a/torod/db-wrappers/postgresql/src/main/resources/sql/twelve_bytes_type.sql
+++ b/torod/db-wrappers/postgresql/src/main/resources/sql/twelve_bytes_type.sql
@@ -1,1 +1,1 @@
-CREATE DOMAIN twelve_bytes AS bytea;
+CREATE DOMAIN torodb.twelve_bytes AS bytea;

--- a/torod/db-wrappers/postgresql/src/main/resources/sql/varchar_to_jsonb.sql
+++ b/torod/db-wrappers/postgresql/src/main/resources/sql/varchar_to_jsonb.sql
@@ -1,3 +1,3 @@
-CREATE OR REPLACE FUNCTION varchar_to_jsonb(varchar) RETURNS jsonb AS $$
+CREATE OR REPLACE FUNCTION torodb.varchar_to_jsonb(varchar) RETURNS jsonb AS $$
 SELECT jsonb_in($1::cstring); 
 $$ LANGUAGE SQL IMMUTABLE;


### PR DESCRIPTION
Fixed issue #20 as discussed in the mailing list:

"The hardest one: as these procedures and types belongs to torodb, leave in torodb schema, changing all SQL sentences:
CREATE TYPE torodb.find_doc_type AS (did int, typeid int, index int, _json text);
and also changing all code references to these procedures and types, from the public schema to torodb schema"

