### PR TITLE
Moved to Java 7, added travis support and improved pom.xml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: java
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+  - openjdk6
+
+sudo: false
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
 
 sudo: false
 
-after_success:
+before_deploy:
   - echo "<settings><servers><server><id>ossrh-snapshot</id><username>\${env.MAVEN_DEPLOY_USER}</username><password>\${env.MAVEN_DEPLOY_PASS}</password></server><server><id>ossrh-release</id><username>\${env.MAVEN_DEPLOY_USER}</username><password>\${env.MAVEN_DEPLOY_PASS}</password></server></servers></settings>" > ~/settings.xml
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ deploy:
   api_key:
     secure: P3gWBmh516lPjW8jT+wUSmOzTrUTB+rgGWujdzZXa+NwhjwaGUckNHHGB/czcyc7JjwaA+v5Q3+js3ygJzcpjEzN2juYuSMD9V9aflhtoH3aH2L6yunkZXQE3rD44/SneoaWZ9tE8Knuj3MyeaetqdJQWQx3AF1gxsERQcnTDVz4bMHpFoY27JqAVYTZ3LAYL0fKP2pvNiCd7Ye1MzuHFDdlBJhFC6GUkfd7+9gq9ZpMZkar6z0kKudiJlG4m79ppx7pxgmrD8hB7DbGQ2Vfl6Jx9YOlZh7mf51uLHpiZqq+lE0UYOQcr3E8uDUAriuu9vzIrCgNHGladlvNvh69SNQwwOEchgLtIw/gZaqCBlDkxtnqGqBw2zGJdZnoPffos/2jKp1wCUij2xbE9ZywyLXf1Kep2WkUrTypD/1FbOAP8ORAdwVB2Ozw/lIwpX0AUvVBiBI7FizYUUal7DOjByAWLvshbVhJcOoEXsFVD1dEVvWIN5XSpHmcV09qBaRzL+qRFd/pTTRKd5rig31clmEC9at4zTCXVrI5v1ntWHOVcB3tiQO8T0BmK87pHHPAgdG91z6U4MBsR9l9rK7OO1uvj7oXSRoW1Bf8rqOV0Wt/BfLXvJUIsaJqaVah6L7ybVFQfgAfkso2VppQkqBH/UtttkNKmQU6VH/Bqxjfgs0=
   skip_cleanup: true
+  file:
+      - torodb/target/dist/torodb-0.40-SNAPSHOT-bin.tar.bz2
+      - torodb/target/dist/torodb-0.40-SNAPSHOT-bin.tar.gz
+      - torodb/target/dist/torodb-0.40-SNAPSHOT-bin.zip
   on:
     repo: gortiz/torodb
-    branch: ci
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: java
-script: mvn -Psafer -Passembler -B -e -T 1C clean install
+script: mvn -Psafer -Passembler -B -e -T 1C verify
 jdk:
 - oraclejdk8
 - oraclejdk7
 
 before_script:
-  - export GIT_BRANCH=$TRAVIS_BRANCH
+- export GIT_BRANCH=$TRAVIS_BRANCH
 
 sudo: false
 
@@ -13,28 +13,29 @@ after_success:
   - echo "<settings><servers><server><id>ossrh-snapshot</id><username>\${env.MAVEN_DEPLOY_USER}</username><password>\${env.MAVEN_DEPLOY_PASS}</password></server><server><id>ossrh-release</id><username>\${env.MAVEN_DEPLOY_USER}</username><password>\${env.MAVEN_DEPLOY_PASS}</password></server></servers></settings>" > ~/settings.xml
 
 deploy:
-  - provider: releases
-    api_key:
-      secure: P3gWBmh516lPjW8jT+wUSmOzTrUTB+rgGWujdzZXa+NwhjwaGUckNHHGB/czcyc7JjwaA+v5Q3+js3ygJzcpjEzN2juYuSMD9V9aflhtoH3aH2L6yunkZXQE3rD44/SneoaWZ9tE8Knuj3MyeaetqdJQWQx3AF1gxsERQcnTDVz4bMHpFoY27JqAVYTZ3LAYL0fKP2pvNiCd7Ye1MzuHFDdlBJhFC6GUkfd7+9gq9ZpMZkar6z0kKudiJlG4m79ppx7pxgmrD8hB7DbGQ2Vfl6Jx9YOlZh7mf51uLHpiZqq+lE0UYOQcr3E8uDUAriuu9vzIrCgNHGladlvNvh69SNQwwOEchgLtIw/gZaqCBlDkxtnqGqBw2zGJdZnoPffos/2jKp1wCUij2xbE9ZywyLXf1Kep2WkUrTypD/1FbOAP8ORAdwVB2Ozw/lIwpX0AUvVBiBI7FizYUUal7DOjByAWLvshbVhJcOoEXsFVD1dEVvWIN5XSpHmcV09qBaRzL+qRFd/pTTRKd5rig31clmEC9at4zTCXVrI5v1ntWHOVcB3tiQO8T0BmK87pHHPAgdG91z6U4MBsR9l9rK7OO1uvj7oXSRoW1Bf8rqOV0Wt/BfLXvJUIsaJqaVah6L7ybVFQfgAfkso2VppQkqBH/UtttkNKmQU6VH/Bqxjfgs0=
-    skip_cleanup: true
-    file:
-    - torodb/target/dist/torodb.tar.bz2
-    - torodb/target/dist/torodb.zip
-    on:
-      repo: gortiz/torodb
-      tags: true
-      jdk: oraclejdk8
-  - provider: script
-    script: mvn -B -e -T 1C -Pdeploy -DskipTests=true deploy --settings ~/settings.xml
-    skip_cleanup: true
-    on:
-      repo: gortiz/torodb
-      tags: true
-      jdk: oraclejdk8
-  - provider: script
-    script: mvn -B -e -T 1C -Pdeploy -DskipTests=true deploy --settings ~/settings.xml
-    skip_cleanup: true
-    on:
-      repo: gortiz/torodb
-      branch: devel
-      jdk: oraclejdk8
+- provider: releases
+  api_key:
+    secure: g2kUTryp5anBi6xzkHT4CfTFJz3K1q1nYYwjtNfreCoEGrjTA6A4ZgU/utVTOJxeNWmKZ1QO4suegKfsRCpiSqNvp85lM49qeXAp/xxuI0ac+J7JJALeGEn0AyLmhuHu/BBm3dIG+6oi+cXRsTKAX8uTqrT9P1tkfaUhEEV1XmA4tU3uEqzHiazPUKXysxAOacqeUfvZh+MoZaqA54p0UjmOilTMGnQvpv2uR7tBnXNGVXkqyonH6HsxAOwKdyZAYwsg2hvCNREJUCgl/OVkQI/H8+SmOfZ4btHxZqX3U5iVLZ9CugsUbqflvVzVd7KIPn4DPXalkSDLsJ2SxBio7Y1t50omDIlb7NsClR4JDAzME5XKw8XR9glmC0uDTMxMuhgXYWLq2JgQUlnD8vWh1SGsdUCNa+aQMlcYdIIMQZG50LgY5s+E2YVEzJ7NrWm66UCqeuxjqWetrGin1eFOY0+y2/+Pe4tr2ZhrbGhlqS11GKWy+tKLM9v7+L2w1gjKJaqcmbtVfja1kehaP7JLhq2S2S7jmcTggy4bx5B9U4rVwWq1cv5sXXXNEsvB/PzifXHV3z38O/ed8ddJpCTkhfubAr6zOKkyGdkPvXbdAmDOVWw5JPbP1fWDojaRgqxumf7MUhAlOGxmj//hgpwh/Q8/QVKCJ+lQRq89H5bT0q4=
+  skip_cleanup: true
+  file:
+  - torodb/target/dist/torodb.tar.bz2
+  - torodb/target/dist/torodb.zip
+  on:
+    repo: torodb/torodb
+    tags: true
+    jdk: oraclejdk8
+- provider: script
+  script: mvn -B -e -T 1C -Pdeploy -DskipTests=true deploy --settings ~/settings.xml
+  skip_cleanup: true
+  on:
+    repo: torodb/torodb
+    tags: true
+    jdk: oraclejdk8
+- provider: script
+  script: mvn -B -e -T 1C -Pdeploy -DskipTests=true deploy --settings ~/settings.xml
+  skip_cleanup: true
+  on:
+    repo: torodb/torodb
+    branch: devel
+    jdk: oraclejdk8
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,17 @@
 language: java
 jdk:
-  - oraclejdk8
-  - oraclejdk7
-  - openjdk6
-
+- oraclejdk8
+- oraclejdk7
 sudo: false
-
+before_install:
+- pip install codecov
+after_success:
+- codecov
+deploy:
+  provider: releases
+  api_key:
+    secure: P3gWBmh516lPjW8jT+wUSmOzTrUTB+rgGWujdzZXa+NwhjwaGUckNHHGB/czcyc7JjwaA+v5Q3+js3ygJzcpjEzN2juYuSMD9V9aflhtoH3aH2L6yunkZXQE3rD44/SneoaWZ9tE8Knuj3MyeaetqdJQWQx3AF1gxsERQcnTDVz4bMHpFoY27JqAVYTZ3LAYL0fKP2pvNiCd7Ye1MzuHFDdlBJhFC6GUkfd7+9gq9ZpMZkar6z0kKudiJlG4m79ppx7pxgmrD8hB7DbGQ2Vfl6Jx9YOlZh7mf51uLHpiZqq+lE0UYOQcr3E8uDUAriuu9vzIrCgNHGladlvNvh69SNQwwOEchgLtIw/gZaqCBlDkxtnqGqBw2zGJdZnoPffos/2jKp1wCUij2xbE9ZywyLXf1Kep2WkUrTypD/1FbOAP8ORAdwVB2Ozw/lIwpX0AUvVBiBI7FizYUUal7DOjByAWLvshbVhJcOoEXsFVD1dEVvWIN5XSpHmcV09qBaRzL+qRFd/pTTRKd5rig31clmEC9at4zTCXVrI5v1ntWHOVcB3tiQO8T0BmK87pHHPAgdG91z6U4MBsR9l9rK7OO1uvj7oXSRoW1Bf8rqOV0Wt/BfLXvJUIsaJqaVah6L7ybVFQfgAfkso2VppQkqBH/UtttkNKmQU6VH/Bqxjfgs0=
+  skip_cleanup: true
+  on:
+    repo: gortiz/torodb
+    branch: ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+script: mvn -Ppre-push -Passembler -Penv-deploy install
 jdk:
 - oraclejdk8
 - oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,40 @@
 language: java
-script: mvn -Ppre-push -Passembler -Penv-deploy install
+script: mvn -Psafer -Passembler -B -e -T 1C clean install
 jdk:
 - oraclejdk8
 - oraclejdk7
+
+before_script:
+  - export GIT_BRANCH=$TRAVIS_BRANCH
+
 sudo: false
-#before_install:
-#- pip install codecov
-#after_success:
-#- codecov
+
+after_success:
+  - echo "<settings><servers><server><id>ossrh-snapshot</id><username>\${env.MAVEN_DEPLOY_USER}</username><password>\${env.MAVEN_DEPLOY_PASS}</password></server><server><id>ossrh-release</id><username>\${env.MAVEN_DEPLOY_USER}</username><password>\${env.MAVEN_DEPLOY_PASS}</password></server></servers></settings>" > ~/settings.xml
+
 deploy:
-  provider: releases
-  api_key:
-    secure: P3gWBmh516lPjW8jT+wUSmOzTrUTB+rgGWujdzZXa+NwhjwaGUckNHHGB/czcyc7JjwaA+v5Q3+js3ygJzcpjEzN2juYuSMD9V9aflhtoH3aH2L6yunkZXQE3rD44/SneoaWZ9tE8Knuj3MyeaetqdJQWQx3AF1gxsERQcnTDVz4bMHpFoY27JqAVYTZ3LAYL0fKP2pvNiCd7Ye1MzuHFDdlBJhFC6GUkfd7+9gq9ZpMZkar6z0kKudiJlG4m79ppx7pxgmrD8hB7DbGQ2Vfl6Jx9YOlZh7mf51uLHpiZqq+lE0UYOQcr3E8uDUAriuu9vzIrCgNHGladlvNvh69SNQwwOEchgLtIw/gZaqCBlDkxtnqGqBw2zGJdZnoPffos/2jKp1wCUij2xbE9ZywyLXf1Kep2WkUrTypD/1FbOAP8ORAdwVB2Ozw/lIwpX0AUvVBiBI7FizYUUal7DOjByAWLvshbVhJcOoEXsFVD1dEVvWIN5XSpHmcV09qBaRzL+qRFd/pTTRKd5rig31clmEC9at4zTCXVrI5v1ntWHOVcB3tiQO8T0BmK87pHHPAgdG91z6U4MBsR9l9rK7OO1uvj7oXSRoW1Bf8rqOV0Wt/BfLXvJUIsaJqaVah6L7ybVFQfgAfkso2VppQkqBH/UtttkNKmQU6VH/Bqxjfgs0=
-  skip_cleanup: true
-  file:
-      - torodb/target/dist/torodb-0.40-SNAPSHOT-bin.tar.bz2
-      - torodb/target/dist/torodb-0.40-SNAPSHOT-bin.tar.gz
-      - torodb/target/dist/torodb-0.40-SNAPSHOT-bin.zip
-  on:
-    repo: gortiz/torodb
-    tags: true
+  - provider: releases
+    api_key:
+      secure: P3gWBmh516lPjW8jT+wUSmOzTrUTB+rgGWujdzZXa+NwhjwaGUckNHHGB/czcyc7JjwaA+v5Q3+js3ygJzcpjEzN2juYuSMD9V9aflhtoH3aH2L6yunkZXQE3rD44/SneoaWZ9tE8Knuj3MyeaetqdJQWQx3AF1gxsERQcnTDVz4bMHpFoY27JqAVYTZ3LAYL0fKP2pvNiCd7Ye1MzuHFDdlBJhFC6GUkfd7+9gq9ZpMZkar6z0kKudiJlG4m79ppx7pxgmrD8hB7DbGQ2Vfl6Jx9YOlZh7mf51uLHpiZqq+lE0UYOQcr3E8uDUAriuu9vzIrCgNHGladlvNvh69SNQwwOEchgLtIw/gZaqCBlDkxtnqGqBw2zGJdZnoPffos/2jKp1wCUij2xbE9ZywyLXf1Kep2WkUrTypD/1FbOAP8ORAdwVB2Ozw/lIwpX0AUvVBiBI7FizYUUal7DOjByAWLvshbVhJcOoEXsFVD1dEVvWIN5XSpHmcV09qBaRzL+qRFd/pTTRKd5rig31clmEC9at4zTCXVrI5v1ntWHOVcB3tiQO8T0BmK87pHHPAgdG91z6U4MBsR9l9rK7OO1uvj7oXSRoW1Bf8rqOV0Wt/BfLXvJUIsaJqaVah6L7ybVFQfgAfkso2VppQkqBH/UtttkNKmQU6VH/Bqxjfgs0=
+    skip_cleanup: true
+    file:
+    - torodb/target/dist/torodb.tar.bz2
+    - torodb/target/dist/torodb.zip
+    on:
+      repo: gortiz/torodb
+      tags: true
+      jdk: oraclejdk8
+  - provider: script
+    script: mvn -B -e -T 1C -Pdeploy -DskipTests=true deploy --settings ~/settings.xml
+    skip_cleanup: true
+    on:
+      repo: gortiz/torodb
+      tags: true
+      jdk: oraclejdk8
+  - provider: script
+    script: mvn -B -e -T 1C -Pdeploy -DskipTests=true deploy --settings ~/settings.xml
+    skip_cleanup: true
+    on:
+      repo: gortiz/torodb
+      branch: devel
+      jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ jdk:
 - oraclejdk8
 - oraclejdk7
 sudo: false
-before_install:
-- pip install codecov
-after_success:
-- codecov
+#before_install:
+#- pip install codecov
+#after_success:
+#- codecov
 deploy:
   provider: releases
   api_key:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For more information, please see [ToroDB's website][1], this [latest presentatio
 
 ToroDB is written in Java and requires:
 
-* A suitable JRE, version 6 or higher. It has been mainly tested with Oracle JRE 8.
+* A suitable JRE, version 7 or higher. It has been mainly tested with Oracle JRE 8.
 * A [PostgreSQL][2] database, version 9.4 or higher. [Download][9].
 
 
@@ -19,7 +19,7 @@ ToroDB is written in Java and requires:
 
 ### Download the compiled jar file
 
-You may download the [latest version][3] (v. 0.23-SNAPSHOT) of ToroDB from ToroDB's maven repository. See below for instructions on how to run it.
+You may download the [latest version][3] (v. 0.40-SNAPSHOT) of ToroDB from ToroDB's maven repository. See below for instructions on how to run it.
 
 
 ### Compile and install from sources
@@ -28,7 +28,7 @@ You may compile ToroDB yourself. All the project is written in Java and managed 
 
 ToroDB is based on the [Mongo Wire Protocol library][5] (mongowp), which is another library built by [8Kdata][6] to help construct programs that speak the MongoDB protocol. You may also compile this library yourself, or let maven download it from the repository automatically.
 
-Just run `mvn package` on the root directory and find the executable jar file in `torodb/target/torodb-0.23-SNAPSHOT-jar-with-dependencies.jar`.
+Just run `mvn package` on the root directory and find the executable jar file in `torodb/target/torodb-0.40-SNAPSHOT-jar-with-dependencies.jar`.
 
 
 ## Running ToroDB
@@ -79,7 +79,7 @@ Please see [CONTRIBUTING][10].
 
 [1]: http://www.torodb.com
 [2]: http://www.postgresql.org
-[3]: http://maven.torodb.com/jar/com/torodb/torodb/0.23-SNAPSHOT/torodb.jar
+[3]: http://maven.torodb.com/jar/com/torodb/torodb/0.40-SNAPSHOT/torodb.jar
 [4]: http://www.postgresql.org/docs/9.3/static/libpq-pgpass.html
 [5]: https://github.com/8kdata/mongowp
 [6]: http://www.8kdata.com

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ For more information, please see [ToroDB's website][1], this
 ToroDB.
 
 ## Code QA
-[![Master branch build status](https://travis-ci.org/gortiz/torodb.svg?branch=master)](https://travis-ci.org/gortiz/torodb)
-[![Devel branch build status](https://travis-ci.org/gortiz/torodb.svg?branch=devel)](https://travis-ci.org/gortiz/torodb)
+ * Master branch build status: [![Master branch build status](https://travis-ci.org/torodb/torodb.svg?branch=master)](https://travis-ci.org/torodb/torodb)
+ * Devel branch build status :  [![Devel branch build status](https://travis-ci.org/torodb/torodb.svg?branch=devel)](https://travis-ci.org/torodb/torodb)
 
 
 ## Requisites
@@ -32,10 +32,10 @@ ToroDB is written in Java and requires:
 ### Download the compiled file
 
 You may download the latest version (v. 0.40-SNAPSHOT) of ToroDB from 
-[the release tab][https://github.com/gortiz/torodb/releases/latest] on the 
+[the release page](https://github.com/torodb/torodb/releases/latest) on the 
 following packaging formats:
- * [tar.bz2][https://github.com/gortiz/torodb/releases/latest/torodb.tar.bz2]
- * [zip][https://github.com/gortiz/torodb/releases/latest/torodb.zip]
+ * [tar.bz2](https://github.com/torodb/torodb/releases/latest/torodb.tar.bz2)
+ * [zip](https://github.com/torodb/torodb/releases/latest/torodb.zip)
 
 See below for instructions on how to run it.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,22 @@
 # ToroDB
 
-ToroDB is an open source, document-oriented, JSON database that runs on top of PostgreSQL. JSON documents are stored relationally, not as a blob/jsonb. This leads to significant storage and I/O savings. It speaks natively the MongoDB protocol, meaning that it can be used with any mongo-compatible client.
+ToroDB is an open source, document-oriented, JSON database that runs on top of 
+PostgreSQL. JSON documents are stored relationally, not as a blob/jsonb. This 
+leads to significant storage and I/O savings. It speaks natively the MongoDB 
+protocol, meaning that it can be used with any mongo-compatible client.
 
-ToroDB follows a RERO (Release Early, Release Often) policy. Current version is considered a "developer preview" and hence is not suitable for production use. However, any feedback, contributions, help and/or patches are very welcome. Please join the [torodb-dev][8] mailing list for further discussion.
+ToroDB follows a RERO (Release Early, Release Often) policy. Current version is
+considered a "developer preview" and hence is not suitable for production use. 
+However, any feedback, contributions, help and/or patches are very welcome. 
+Please join the [torodb-dev][8] mailing list for further discussion.
 
-For more information, please see [ToroDB's website][1], this [latest presentation][7] or this [video recording of a presentation][11] about ToroDB.
+For more information, please see [ToroDB's website][1], this 
+[latest presentation][7] or this [video recording of a presentation][11] about 
+ToroDB.
+
+## Code QA
+[![Master branch build status](https://travis-ci.org/gortiz/torodb.svg?branch=master)](https://travis-ci.org/gortiz/torodb)
+[![Devel branch build status](https://travis-ci.org/gortiz/torodb.svg?branch=devel)](https://travis-ci.org/gortiz/torodb)
 
 
 ## Requisites
@@ -17,9 +29,17 @@ ToroDB is written in Java and requires:
 
 ## Download/Installation
 
-### Download the compiled jar file
+### Download the compiled file
 
-You may download the [latest version][3] (v. 0.40-SNAPSHOT) of ToroDB from ToroDB's maven repository. See below for instructions on how to run it.
+You may download the latest version (v. 0.40-SNAPSHOT) of ToroDB from 
+[the release tab][https://github.com/gortiz/torodb/releases/latest] on the 
+following packaging formats:
+ * [tar.bz2][https://github.com/gortiz/torodb/releases/latest/torodb.tar.bz2]
+ * [zip][https://github.com/gortiz/torodb/releases/latest/torodb.zip]
+
+See below for instructions on how to run it.
+
+You can also find binary files on ToroDB's maven repository[3].
 
 
 ### Compile and install from sources
@@ -28,12 +48,15 @@ You may compile ToroDB yourself. All the project is written in Java and managed 
 
 ToroDB is based on the [Mongo Wire Protocol library][5] (mongowp), which is another library built by [8Kdata][6] to help construct programs that speak the MongoDB protocol. You may also compile this library yourself, or let maven download it from the repository automatically.
 
-Just run `mvn package` on the root directory and find the executable jar file in `torodb/target/torodb-0.40-SNAPSHOT-jar-with-dependencies.jar`.
+Just run `mvn package -Passembler` on the root directory and execute it from 
+`torodb/target/appassembler/bin` or choose your prefered packaging format from
+`torodb/target/dist/`.
 
 
 ## Running ToroDB
 
-Execute with `java -jar <path>/torodb.jar <arguments>`. If you run with `--help`, you will see the required and optional arguments to run ToroDB:
+Execute with `torodb <arguments>` (or `torodb.bat <arguments>` on Windows). If 
+you run with `--help`, you will see the required and optional arguments to run ToroDB:
 
     --ask-for-password
        Force input of PostgreSQL's database user password.
@@ -79,7 +102,7 @@ Please see [CONTRIBUTING][10].
 
 [1]: http://www.torodb.com
 [2]: http://www.postgresql.org
-[3]: http://maven.torodb.com/jar/com/torodb/torodb/0.40-SNAPSHOT/torodb.jar
+[3]: https://oss.sonatype.org/content/groups/public/com/torodb/torodb/
 [4]: http://www.postgresql.org/docs/9.3/static/libpq-pgpass.html
 [5]: https://github.com/8kdata/mongowp
 [6]: http://www.8kdata.com

--- a/file-templates/README.md.mustache
+++ b/file-templates/README.md.mustache
@@ -1,10 +1,22 @@
 # ToroDB
 
-ToroDB is an open source, document-oriented, JSON database that runs on top of PostgreSQL. JSON documents are stored relationally, not as a blob/jsonb. This leads to significant storage and I/O savings. It speaks natively the MongoDB protocol, meaning that it can be used with any mongo-compatible client.
+ToroDB is an open source, document-oriented, JSON database that runs on top of 
+PostgreSQL. JSON documents are stored relationally, not as a blob/jsonb. This 
+leads to significant storage and I/O savings. It speaks natively the MongoDB 
+protocol, meaning that it can be used with any mongo-compatible client.
 
-ToroDB follows a RERO (Release Early, Release Often) policy. Current version is considered a "developer preview" and hence is not suitable for production use. However, any feedback, contributions, help and/or patches are very welcome. Please join the [torodb-dev][8] mailing list for further discussion.
+ToroDB follows a RERO (Release Early, Release Often) policy. Current version is
+considered a "developer preview" and hence is not suitable for production use. 
+However, any feedback, contributions, help and/or patches are very welcome. 
+Please join the [torodb-dev][8] mailing list for further discussion.
 
-For more information, please see [ToroDB's website][1], this [latest presentation][7] or this [video recording of a presentation][11] about ToroDB.
+For more information, please see [ToroDB's website][1], this 
+[latest presentation][7] or this [video recording of a presentation][11] about 
+ToroDB.
+
+## Code QA
+[![Master branch build status](https://travis-ci.org/gortiz/torodb.svg?branch=master)](https://travis-ci.org/gortiz/torodb)
+[![Devel branch build status](https://travis-ci.org/gortiz/torodb.svg?branch=devel)](https://travis-ci.org/gortiz/torodb)
 
 
 ## Requisites
@@ -17,9 +29,17 @@ ToroDB is written in Java and requires:
 
 ## Download/Installation
 
-### Download the compiled jar file
+### Download the compiled file
 
-You may download the [latest version][3] (v. {{latestVersion}}) of ToroDB from ToroDB's maven repository. See below for instructions on how to run it.
+You may download the latest version (v. {{latestVersion}}) of ToroDB from 
+[the release tab][https://github.com/gortiz/torodb/releases/latest] on the 
+following packaging formats:
+ * [tar.bz2][https://github.com/gortiz/torodb/releases/latest/torodb.tar.bz2]
+ * [zip][https://github.com/gortiz/torodb/releases/latest/torodb.zip]
+
+See below for instructions on how to run it.
+
+You can also find binary files on ToroDB's maven repository[3].
 
 
 ### Compile and install from sources
@@ -28,12 +48,15 @@ You may compile ToroDB yourself. All the project is written in Java and managed 
 
 ToroDB is based on the [Mongo Wire Protocol library][5] (mongowp), which is another library built by [8Kdata][6] to help construct programs that speak the MongoDB protocol. You may also compile this library yourself, or let maven download it from the repository automatically.
 
-Just run `mvn package` on the root directory and find the executable jar file in `torodb/target/torodb-{{latestVersion}}-jar-with-dependencies.jar`.
+Just run `mvn package -Passembler` on the root directory and execute it from 
+`torodb/target/appassembler/bin` or choose your prefered packaging format from
+`torodb/target/dist/`.
 
 
 ## Running ToroDB
 
-Execute with `java -jar <path>/torodb.jar <arguments>`. If you run with `--help`, you will see the required and optional arguments to run ToroDB:
+Execute with `torodb <arguments>` (or `torodb.bat <arguments>` on Windows). If 
+you run with `--help`, you will see the required and optional arguments to run ToroDB:
 
     --ask-for-password
        Force input of PostgreSQL's database user password.
@@ -79,7 +102,7 @@ Please see [CONTRIBUTING][10].
 
 [1]: http://www.torodb.com
 [2]: http://www.postgresql.org
-[3]: https://oss.sonatype.org/content/groups/public/com/torodb/torodb/{{latestVersion}}/torodb.jar
+[3]: https://oss.sonatype.org/content/groups/public/com/torodb/torodb/
 [4]: http://www.postgresql.org/docs/9.3/static/libpq-pgpass.html
 [5]: https://github.com/8kdata/mongowp
 [6]: http://www.8kdata.com

--- a/file-templates/README.md.mustache
+++ b/file-templates/README.md.mustache
@@ -15,8 +15,8 @@ For more information, please see [ToroDB's website][1], this
 ToroDB.
 
 ## Code QA
-[![Master branch build status](https://travis-ci.org/gortiz/torodb.svg?branch=master)](https://travis-ci.org/gortiz/torodb)
-[![Devel branch build status](https://travis-ci.org/gortiz/torodb.svg?branch=devel)](https://travis-ci.org/gortiz/torodb)
+ * Master branch build status: [![Master branch build status](https://travis-ci.org/torodb/torodb.svg?branch=master)](https://travis-ci.org/torodb/torodb)
+ * Devel branch build status :  [![Devel branch build status](https://travis-ci.org/torodb/torodb.svg?branch=devel)](https://travis-ci.org/torodb/torodb)
 
 
 ## Requisites
@@ -32,10 +32,10 @@ ToroDB is written in Java and requires:
 ### Download the compiled file
 
 You may download the latest version (v. {{latestVersion}}) of ToroDB from 
-[the release tab][https://github.com/gortiz/torodb/releases/latest] on the 
+[the release page](https://github.com/torodb/torodb/releases/latest) on the 
 following packaging formats:
- * [tar.bz2][https://github.com/gortiz/torodb/releases/latest/torodb.tar.bz2]
- * [zip][https://github.com/gortiz/torodb/releases/latest/torodb.zip]
+ * [tar.bz2](https://github.com/torodb/torodb/releases/latest/torodb.tar.bz2)
+ * [zip](https://github.com/torodb/torodb/releases/latest/torodb.zip)
 
 See below for instructions on how to run it.
 

--- a/file-templates/README.md.mustache
+++ b/file-templates/README.md.mustache
@@ -11,7 +11,7 @@ For more information, please see [ToroDB's website][1], this [latest presentatio
 
 ToroDB is written in Java and requires:
 
-* A suitable JRE, version 6 or higher. It has been mainly tested with Oracle JRE 8.
+* A suitable JRE, version 7 or higher. It has been mainly tested with Oracle JRE 8.
 * A [PostgreSQL][2] database, version 9.4 or higher. [Download][9].
 
 
@@ -79,7 +79,7 @@ Please see [CONTRIBUTING][10].
 
 [1]: http://www.torodb.com
 [2]: http://www.postgresql.org
-[3]: http://maven.torodb.com/jar/com/torodb/torodb/{{latestVersion}}/torodb.jar
+[3]: https://oss.sonatype.org/content/groups/public/com/torodb/torodb/{{latestVersion}}/torodb.jar
 [4]: http://www.postgresql.org/docs/9.3/static/libpq-pgpass.html
 [5]: https://github.com/8kdata/mongowp
 [6]: http://www.8kdata.com

--- a/pom.xml
+++ b/pom.xml
@@ -339,6 +339,9 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>2.10.3</version>
+                        <configuration>
+                            <failOnError>false</failOnError>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,10 @@
     
     <name>ToroDB parent</name>
     
+    <prerequisites>
+        <maven>3.2.2</maven>
+    </prerequisites>
+    
     <organization>
         <name>8Kdata</name>
         <url>www.8kdata.com</url>
@@ -41,13 +45,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
         <torod.version>${project.version}</torod.version>
-
-        <S3.bucket>maven.torodb.com</S3.bucket>
-        <deploy.repository>http://${S3.bucket}</deploy.repository>
-        <deploy.repository.release.urlpath>release</deploy.repository.release.urlpath>
-        <deploy.repository.snapshot.urlpath>snapshot</deploy.repository.snapshot.urlpath>
     </properties>
 
     <modules>
@@ -56,44 +54,6 @@
         <module>torodb</module>
         <module>multiple-granularity-locking</module>
     </modules>
-
-    <repositories>  
-        <repository>  
-            <id>aws-release</id>
-            <name>S3 Release Repository</name>  
-            <url>${deploy.repository}/${deploy.repository.release.urlpath}</url>
-            <releases>  
-                <enabled>true</enabled>  
-            </releases>  
-            <snapshots>  
-                <enabled>false</enabled>  
-            </snapshots>  
-        </repository>  
-        <repository>  
-            <id>aws-snapshot</id>
-            <name>S3 Snapshot Repository</name>  
-            <url>${deploy.repository}/${deploy.repository.snapshot.urlpath}</url>
-            <releases>  
-                <enabled>false</enabled>  
-            </releases>  
-            <snapshots>  
-                <enabled>true</enabled>  
-            </snapshots>  
-        </repository>
-    </repositories>
-
-    <distributionManagement>
-        <repository>  
-            <id>aws-release</id>
-            <name>S3 Release Repository</name>  
-            <url>s3://${S3.bucket}/${deploy.repository.release.urlpath}</url>
-        </repository>
-        <snapshotRepository>  
-            <id>aws-snapshot</id>  
-            <name>S3 Snapshot Repository</name>  
-            <url>s3://${S3.bucket}/${deploy.repository.snapshot.urlpath}</url>
-        </snapshotRepository>
-    </distributionManagement> 
 
     <dependencyManagement>
         <dependencies>
@@ -236,36 +196,131 @@
                 <artifactId>mockito-core</artifactId>
                 <version>1.10.19</version>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <!-- version 1.10.19 depends on hamcrest-core:1.1, meanwhile junit 4.12 depends on hamcrest-core:1.3 -->
+                        <groupId>org.hamcrest</groupId>
+                        <artifactId>hamcrest-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
         </dependencies>
     </dependencyManagement>
 
     <build>
-        <extensions>
-            <extension>
-                <groupId>org.springframework.build</groupId>
-                <artifactId>aws-maven</artifactId>
-                <version>5.0.0.RELEASE</version>
-            </extension>
-        </extensions>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                    <compilerArgument>-Xlint:all</compilerArgument>
+                    <showDeprecation>true</showDeprecation>
+                    <showWarnings>true</showWarnings> 
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>2.7</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.19</version>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>
+                                <exclude>%regex[.*integration.*]</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.4.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce-dependencies</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <dependencyConvergence/>
+                                <requireReleaseDeps>
+                                    <message>Artifacts must not depend on external snapshot!</message>
+                                    <excludes>
+                                        <exclude>com.8kdata*:*</exclude>
+                                        <exclude>com.torodb*:*</exclude>
+                                    </excludes>
+                                    <failWhenParentIsSnapshot>false</failWhenParentIsSnapshot>
+                                </requireReleaseDeps>
+                            </rules>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>enforce-dependencies-release</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireReleaseDeps>
+                                    <message>Release artifacts must not depend on any snapshot!</message>
+                                    <onlyWhenRelease>true</onlyWhenRelease>
+                                </requireReleaseDeps>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <profiles>
         <profile>
-            <id>jdk6</id>
+            <id>env-deploy</id>
             <activation>
-                <jdk>1.6</jdk>
+                <property>
+                    <name>env</name>                    
+                    <value>deploy</value>
+                </property>
             </activation>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.3</version>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.19</version>
                         <configuration>
-                            <source>1.6</source>
-                            <target>1.6</target>
+                            <skip>true</skip>
                         </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-tests</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>false</skip>
+                                    <includes>
+                                        <include>%regex[.*integration.*]</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -275,27 +330,39 @@
                             <execution>
                                 <id>attach-sources</id>
                                 <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>2.10.3</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
                                     <goal>jar</goal>
                                 </goals>
                             </execution>
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>findbugs-maven-plugin</artifactId>
-                        <version>2.5.5</version>
-                        <configuration>
-                            <effort>Max</effort>
-                            <threshold>Low</threshold>
-                            <xmlOutput>true</xmlOutput>
-                            <findbugsXmlOutputDirectory>${project.build.directory}/findbugs</findbugsXmlOutputDirectory>
-                        </configuration>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>0.7.5.201505241946</version>
                         <executions>
                             <execution>
-                                <id>analyze-compile</id>
-                                <phase>compile</phase>
                                 <goals>
-                                    <goal>check</goal>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>report</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>report</goal>
                                 </goals>
                             </execution>
                         </executions>
@@ -304,38 +371,13 @@
             </build>
         </profile>
         <profile>
-            <id>default</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
+            <id>pre-push</id>
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.3</version>
-                        <configuration>
-                            <source>1.6</source>
-                            <target>1.6</target>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <version>2.4</version>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>findbugs-maven-plugin</artifactId>
-                        <version>3.0.1</version>
+                        <version>3.0.3</version>
                         <configuration>
                             <effort>Max</effort>
                             <threshold>Low</threshold>
@@ -345,7 +387,6 @@
                         <executions>
                             <execution>
                                 <id>analyze-compile</id>
-                                <phase>compile</phase>
                                 <goals>
                                     <goal>check</goal>
                                 </goals>
@@ -383,5 +424,58 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>master-branch</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <version>1.4.1</version>
+                        <executions>
+                            <execution>
+                                <id>enforce-release</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireReleaseVersion>
+                                            <message>Artifacts on master branch must not be snapshot!</message>
+                                        </requireReleaseVersion>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
+    
+    <repositories>  
+        <repository>
+            <id>OSSRH</id>
+            <url>https://oss.sonatype.org/content/groups/public</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+    </repositories>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh-snapshot</id>
+            <name>OSSRH Snapshot repository</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh-release</id>
+            <name>OSSRH Release repository</name>  
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+        </repository>
+    </distributionManagement> 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -290,38 +290,9 @@
 
     <profiles>
         <profile>
-            <id>env-deploy</id>
-            <activation>
-                <property>
-                    <name>env</name>                    
-                    <value>deploy</value>
-                </property>
-            </activation>
+            <id>deploy</id> <!-- It must be manually turn on when mvn deploy is executed -->
             <build>
                 <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.19</version>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>integration-tests</id>
-                                <phase>integration-test</phase>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <configuration>
-                                    <skip>false</skip>
-                                    <includes>
-                                        <include>%regex[.*integration.*]</include>
-                                    </includes>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
@@ -374,7 +345,7 @@
             </build>
         </profile>
         <profile>
-            <id>pre-push</id>
+            <id>safer</id> <!-- Slower but safer profile used to look for errors before pushing to SCM -->
             <build>
                 <plugins>
                     <plugin>
@@ -424,11 +395,40 @@
                             </templates>
                         </configuration>
                     </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.19</version>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>integration-tests</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>false</skip>
+                                    <includes>
+                                        <include>%regex[.*integration.*]</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
         <profile>
             <id>master-branch</id>
+            <activation>
+                <property> <!-- Used by Travis to modify the execution by branch -->
+                    <name>env.GIT_BRANCH</name>
+                    <value>master</value>
+                </property>
+            </activation>
             <build>
                 <plugins>
                     <plugin>

--- a/torodb/pom.xml
+++ b/torodb/pom.xml
@@ -156,6 +156,7 @@
                             <descriptors>
                                 <descriptor>src/main/assembly/assembly.xml</descriptor>
                             </descriptors>
+                            <finalName>torodb</finalName>
                             <outputDirectory>${project.build.directory}/dist</outputDirectory>
                         </configuration>
                         <executions>

--- a/torodb/pom.xml
+++ b/torodb/pom.xml
@@ -123,35 +123,6 @@
     <build>        
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.5.3</version>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <mainClass>com.torodb.Main</mainClass>
-                        </manifest>
-                    </archive>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>make-assembly</id> <!-- this is used for inheritance merges -->
-                        <phase>package</phase> <!-- bind to the packaging phase -->
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>2.7</version>
-            </plugin>
-            <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
                 <version>2.1.12</version>
@@ -163,37 +134,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>appassembler-maven-plugin</artifactId>
-                <version>1.10</version>
-                <configuration>
-                    <programs>
-                        <program>
-                            <mainClass>com.torodb.Main</mainClass>
-                            <id>torodb</id>
-                        </program>
-                    </programs>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>assemble</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>assemble</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
         </plugins>
 
         <resources>
@@ -203,4 +143,78 @@
             </resource>
         </resources>
     </build>
+    
+    <profiles>
+        <profile>
+            <id>assembler</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/assembly.xml</descriptor>
+                            </descriptors>
+                            <outputDirectory>${project.build.directory}/dist</outputDirectory>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>assembly</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>appassembler-maven-plugin</artifactId>
+                        <version>1.10</version>
+                        <configuration>
+                            <programs>
+                                <program>
+                                    <mainClass>com.torodb.Main</mainClass>
+                                    <id>torodb</id>
+                                </program>
+                            </programs>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>assemble</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>assemble</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+<!--                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <version>2.5.3</version>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <mainClass>com.torodb.Main</mainClass>
+                                </manifest>
+                            </archive>
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>make-assembly</id>  this is used for inheritance merges 
+                                <phase>package</phase>  bind to the packaging phase 
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>-->
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/torodb/src/main/assembly/assembly.xml
+++ b/torodb/src/main/assembly/assembly.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
-    <id>bin</id>
+    <!--<id>bin</id>-->
     <formats>
-        <format>tar.gz</format>
         <format>tar.bz2</format>
         <format>zip</format>
     </formats>

--- a/torodb/src/main/assembly/assembly.xml
+++ b/torodb/src/main/assembly/assembly.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>bin</id>
+    <formats>
+        <format>tar.gz</format>
+        <format>tar.bz2</format>
+        <format>zip</format>
+    </formats>
+    <fileSets>
+        <fileSet>
+            <directory>target/appassembler/bin</directory>
+            <outputDirectory>bin</outputDirectory>
+            <excludes>
+                <exclude>*.bat</exclude>
+            </excludes>
+            <directoryMode>0755</directoryMode>
+            <fileMode>0755</fileMode>
+        </fileSet>
+        <fileSet>
+            <directory>target/appassembler/bin</directory>
+            <outputDirectory>bin</outputDirectory>
+            <includes>
+                <include>*.bat</include>
+            </includes>
+            <directoryMode>0755</directoryMode>
+            <fileMode>0644</fileMode>
+        </fileSet>
+        <fileSet>
+            <directory>target/appassembler/repo</directory>
+            <outputDirectory>repo</outputDirectory>
+            <directoryMode>0755</directoryMode>
+            <fileMode>0644</fileMode>
+        </fileSet>
+    </fileSets>
+</assembly>


### PR DESCRIPTION
These commits add support to use Travis CI and improves the pom.xml in several ways:

* distribution management points to OSSRH
* 3 profiles have been add
    * _deploy_ is designed to be active when Travis tries to deploy maven artifacts to OSSRH
    * _safer_ is designed to be active before commits and specially pushes to github. It enables findbugs and future integration tests.
    * _master-branch_ is designed to be active only when the master branch is compiled (Travis automatically does it) and it checks that there are no snapshot dependencies or modules on the maven projects.

By the way, this version of ToroDB requires JDK 7 to be compiled and JRE 7 to be executed. In fact, the used plugins are the ones that add that dependency, but ToroDB code have not been modified (yet!)
