### PR TITLE
Sql command

### DIFF
--- a/kvdocument/mongo-converter/src/main/java/com/torodb/kvdocument/conversion/mongo/MongoValueConverter.java
+++ b/kvdocument/mongo-converter/src/main/java/com/torodb/kvdocument/conversion/mongo/MongoValueConverter.java
@@ -22,13 +22,15 @@ package com.torodb.kvdocument.conversion.mongo;
 
 import com.google.common.primitives.UnsignedInteger;
 import com.torodb.kvdocument.types.GenericType;
-import com.torodb.kvdocument.values.*;
 import com.torodb.kvdocument.values.StringValue;
+import com.torodb.kvdocument.values.*;
 import java.util.Map;
 import java.util.regex.Pattern;
 import org.bson.*;
 import org.bson.types.ObjectId;
-import org.threeten.bp.*;
+import org.threeten.bp.Instant;
+import org.threeten.bp.LocalDateTime;
+import org.threeten.bp.ZoneOffset;
 
 /**
  *
@@ -55,6 +57,10 @@ public class MongoValueConverter {
             builder.setElementType(GenericType.INSTANCE);
         }
         return builder.build();
+    }
+
+    public static BsonValue translateDocValue(DocValue docValue) {
+        return docValue.accept(KV_VALUE_TRANSATOR, null);
     }
 
     public static BsonDocument translateObject(ObjectValue object) {
@@ -125,7 +131,7 @@ public class MongoValueConverter {
     public static String patternFlagsToOptions(int flags) {
         return ""; //TODO: parse regexp options!
     }
-    
+
     private static class KVValueTranslator implements
             DocValueVisitor<BsonValue, Void> {
 
@@ -136,7 +142,7 @@ public class MongoValueConverter {
 
         @Override
         public BsonValue visit(NullValue value, Void arg) {
-            return null;
+            return BsonNull.VALUE;
         }
 
         @Override

--- a/torod/connection/src/main/java/com/toro/torod/connection/DefaultToroTransaction.java
+++ b/torod/connection/src/main/java/com/toro/torod/connection/DefaultToroTransaction.java
@@ -20,11 +20,17 @@
 
 package com.toro.torod.connection;
 
+import com.google.common.base.Function;
+import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.toro.torod.connection.update.Updator;
+import com.torodb.kvdocument.values.DocValue;
+import com.torodb.torod.core.ValueRow;
+import com.torodb.torod.core.ValueRow.TranslatorValueRow;
 import com.torodb.torod.core.WriteFailMode;
 import com.torodb.torod.core.config.DocumentBuilderFactory;
 import com.torodb.torod.core.connection.*;
@@ -45,10 +51,9 @@ import com.torodb.torod.core.pojos.IndexedAttributes;
 import com.torodb.torod.core.pojos.NamedToroIndex;
 import com.torodb.torod.core.subdocument.SplitDocument;
 import com.torodb.torod.core.subdocument.ToroDocument;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
+import com.torodb.torod.core.subdocument.values.StringValue;
+import com.torodb.torod.core.subdocument.values.*;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import javax.annotation.Nonnull;
@@ -211,6 +216,24 @@ public class DefaultToroTransaction implements ToroTransaction {
     }
 
     @Override
+    public ListenableFuture<Iterator<ValueRow<DocValue>>> sqlSelect(String sqlQuery)
+            throws UnsupportedOperationException {
+        ListenableFuture<Iterator<ValueRow<Value>>> valueFuture
+                = sessionTransaction.sqlSelect(sqlQuery);
+
+        IteratorTranslator<ValueRow<Value>, ValueRow<DocValue>> iteratorTranslator
+                = new IteratorTranslator<>(
+                        TranslatorValueRow.getBuilderFunction(new ToDocValueFunction())
+                );
+
+        return Futures.transform(
+                valueFuture,
+                iteratorTranslator,
+                MoreExecutors.directExecutor()
+        );
+    }
+
+    @Override
     public ListenableFuture<UpdateResponse> update(
             String collection,
             List<? extends UpdateOperation> updates,
@@ -358,4 +381,95 @@ public class DefaultToroTransaction implements ToroTransaction {
         throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
+    private static class IteratorTranslator<I,O> implements Function<Iterator<I>, Iterator<O>> {
+
+        private final Function<I, O> function;
+
+        private IteratorTranslator(Function<I, O> function) {
+            this.function = function;
+        }
+
+        @Override
+        public Iterator<O> apply(@Nonnull Iterator<I> input) {
+            return Iterators.transform(input, function);
+        }
+    }
+
+    private static class ToDocValueFunction implements Function<Value, DocValue>, ValueVisitor<DocValue, Void> {
+
+        @Override
+        public DocValue apply(@Nonnull Value input) {
+            return (DocValue) input.accept(this, null);
+        }
+
+        @Override
+        public DocValue visit(BooleanValue value, Void arg) {
+            if (value.getValue()) {
+                return com.torodb.kvdocument.values.BooleanValue.TRUE;
+            }
+            return com.torodb.kvdocument.values.BooleanValue.FALSE;
+        }
+
+        @Override
+        public DocValue visit(NullValue value, Void arg) {
+            return com.torodb.kvdocument.values.NullValue.INSTANCE;
+        }
+
+        @Override
+        public DocValue visit(ArrayValue value, Void arg) {
+            com.torodb.kvdocument.values.ArrayValue.Builder builder
+                    = new com.torodb.kvdocument.values.ArrayValue.Builder();
+
+            for (Value e : value.getValue()) {
+                builder.add((DocValue) e.accept(this, arg));
+            }
+            return builder.build();
+        }
+
+        @Override
+        public DocValue visit(IntegerValue value, Void arg) {
+            return new com.torodb.kvdocument.values.IntegerValue(value.getValue());
+        }
+
+        @Override
+        public DocValue visit(LongValue value, Void arg) {
+            return new com.torodb.kvdocument.values.LongValue(value.getValue());
+        }
+
+        @Override
+        public DocValue visit(DoubleValue value, Void arg) {
+            return new com.torodb.kvdocument.values.DoubleValue(value.getValue());
+        }
+
+        @Override
+        public DocValue visit(StringValue value, Void arg) {
+            return new com.torodb.kvdocument.values.StringValue(value.getValue());
+        }
+
+        @Override
+        public DocValue visit(TwelveBytesValue value, Void arg) {
+            return new com.torodb.kvdocument.values.TwelveBytesValue(value.getValue());
+        }
+
+        @Override
+        public DocValue visit(DateTimeValue value, Void arg) {
+            return new com.torodb.kvdocument.values.DateTimeValue(value.getValue());
+        }
+
+        @Override
+        public DocValue visit(DateValue value, Void arg) {
+            return new com.torodb.kvdocument.values.DateValue(value.getValue());
+        }
+
+        @Override
+        public DocValue visit(TimeValue value, Void arg) {
+            return new com.torodb.kvdocument.values.TimeValue(value.getValue());
+        }
+
+        @Override
+        public DocValue visit(PatternValue value, Void arg) {
+            return new com.torodb.kvdocument.values.PatternValue(value.getValue());
+        }
+
+    }
 }

--- a/torod/d2r/src/main/java/com/torodb/torod/d2r/DefaultD2RTranslator.java
+++ b/torod/d2r/src/main/java/com/torodb/torod/d2r/DefaultD2RTranslator.java
@@ -20,31 +20,23 @@
 
 package com.torodb.torod.d2r;
 
-import com.torodb.torod.core.subdocument.values.BooleanValue;
-import com.torodb.torod.core.subdocument.values.Value;
-import com.torodb.torod.core.subdocument.values.StringValue;
-import com.torodb.torod.core.subdocument.values.ValueVisitor;
-import com.torodb.torod.core.subdocument.values.ArrayValue;
-import com.torodb.torod.core.subdocument.values.IntegerValue;
-import com.torodb.torod.core.subdocument.values.LongValue;
-import com.torodb.torod.core.subdocument.values.DoubleValue;
-import com.torodb.torod.core.subdocument.values.NullValue;
+import com.torodb.kvdocument.types.GenericType;
+import com.torodb.kvdocument.values.DocValue;
+import com.torodb.kvdocument.values.ObjectValue;
 import com.torodb.torod.core.config.DocumentBuilderFactory;
 import com.torodb.torod.core.d2r.D2RTranslator;
 import com.torodb.torod.core.dbMetaInf.DbMetaInformationCache;
 import com.torodb.torod.core.executor.SessionExecutor;
-import com.torodb.torod.core.subdocument.structure.DocStructure;
 import com.torodb.torod.core.subdocument.SplitDocument;
 import com.torodb.torod.core.subdocument.SubDocument;
-import javax.inject.Inject;
 import com.torodb.torod.core.subdocument.ToroDocument;
 import com.torodb.torod.core.subdocument.structure.ArrayStructure;
+import com.torodb.torod.core.subdocument.structure.DocStructure;
 import com.torodb.torod.core.subdocument.structure.StructureElement;
+import com.torodb.torod.core.subdocument.values.StringValue;
 import com.torodb.torod.core.subdocument.values.*;
-import com.torodb.kvdocument.types.GenericType;
-import com.torodb.kvdocument.values.DocValue;
-import com.torodb.kvdocument.values.ObjectValue;
 import java.util.Map;
+import javax.inject.Inject;
 
 /**
  *

--- a/torod/db-executor/src/main/java/com/torodb/torod/db/executor/DefaultSessionTransaction.java
+++ b/torod/db-executor/src/main/java/com/torodb/torod/db/executor/DefaultSessionTransaction.java
@@ -21,6 +21,7 @@ package com.torodb.torod.db.executor;
 
 import com.google.common.base.Supplier;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.torodb.torod.core.ValueRow;
 import com.torodb.torod.core.WriteFailMode;
 import com.torodb.torod.core.annotations.DatabaseName;
 import com.torodb.torod.core.connection.DeleteResponse;
@@ -37,9 +38,11 @@ import com.torodb.torod.core.pojos.Database;
 import com.torodb.torod.core.pojos.IndexedAttributes;
 import com.torodb.torod.core.pojos.NamedToroIndex;
 import com.torodb.torod.core.subdocument.SplitDocument;
+import com.torodb.torod.core.subdocument.values.Value;
 import com.torodb.torod.db.executor.jobs.*;
 import com.torodb.torod.db.executor.report.ReportFactory;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
@@ -275,6 +278,18 @@ public class DefaultSessionTransaction implements SessionTransaction {
                       reportFactory.createDropPathViewsReport(),
                       collection
               )
+        );
+    }
+
+    @Override
+    public ListenableFuture<Iterator<ValueRow<Value>>> sqlSelect(String sqlQuery) {
+        return submit(
+                new SqlSelectCallable(
+                        dbConnection,
+                        aborter,
+                        reportFactory.createSqlSelectReport(),
+                        sqlQuery
+                )
         );
     }
 

--- a/torod/db-executor/src/main/java/com/torodb/torod/db/executor/LazyDbWrapper.java
+++ b/torod/db-executor/src/main/java/com/torodb/torod/db/executor/LazyDbWrapper.java
@@ -1,6 +1,7 @@
 
 package com.torodb.torod.db.executor;
 
+import com.torodb.torod.core.ValueRow;
 import com.torodb.torod.core.cursors.CursorId;
 import com.torodb.torod.core.dbWrapper.Cursor;
 import com.torodb.torod.core.dbWrapper.DbConnection;
@@ -17,6 +18,7 @@ import com.torodb.torod.core.pojos.NamedToroIndex;
 import com.torodb.torod.core.subdocument.SplitDocument;
 import com.torodb.torod.core.subdocument.SubDocType;
 import com.torodb.torod.core.subdocument.SubDocument;
+import com.torodb.torod.core.subdocument.values.Value;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -268,6 +270,15 @@ public class LazyDbWrapper implements DbWrapper {
                 IllegalPathViewException {
             try {
                 getDelegate().dropPathViews(collection);
+            } catch (ImplementationDbException ex) {
+                throw new ToroImplementationException(ex);
+            }
+        }
+
+        @Override
+        public Iterator<ValueRow<Value>> select(String query) {
+            try {
+                return getDelegate().select(query);
             } catch (ImplementationDbException ex) {
                 throw new ToroImplementationException(ex);
             }

--- a/torod/db-executor/src/main/java/com/torodb/torod/db/executor/jobs/SqlSelectCallable.java
+++ b/torod/db-executor/src/main/java/com/torodb/torod/db/executor/jobs/SqlSelectCallable.java
@@ -1,0 +1,43 @@
+
+package com.torodb.torod.db.executor.jobs;
+
+import com.torodb.torod.core.ValueRow;
+import com.torodb.torod.core.dbWrapper.DbConnection;
+import com.torodb.torod.core.exceptions.ToroException;
+import com.torodb.torod.core.exceptions.ToroRuntimeException;
+import com.torodb.torod.core.subdocument.values.Value;
+import java.util.Iterator;
+
+/**
+ *
+ */
+public class SqlSelectCallable extends TransactionalJob<Iterator<ValueRow<Value>>> {
+
+    private final Report report;
+    private final String query;
+
+    public SqlSelectCallable(
+            DbConnection connection,
+            TransactionAborter abortCallback,
+            Report report,
+            String query) {
+        super(connection, abortCallback);
+        this.report = report;
+        this.query = query;
+    }
+
+    @Override
+    protected Iterator<ValueRow<Value>> failableCall() throws ToroException,
+            ToroRuntimeException {
+
+        Iterator<ValueRow<Value>> result = getConnection().select(query);
+
+        report.sqlSelectExecuted(query);
+
+        return result;
+    }
+
+    public static interface Report {
+        public void sqlSelectExecuted(String query);
+    }
+}

--- a/torod/db-executor/src/main/java/com/torodb/torod/db/executor/report/AbstractReportFactory.java
+++ b/torod/db-executor/src/main/java/com/torodb/torod/db/executor/report/AbstractReportFactory.java
@@ -155,6 +155,11 @@ public class AbstractReportFactory implements ReportFactory {
         return DUMMY_REPORT;
     }
 
+    @Override
+    public SqlSelectCallable.Report createSqlSelectReport() {
+        return DUMMY_REPORT;
+    }
+
     private static class DummyReport implements CloseConnectionCallable.Report,
             CloseCursorCallable.Report, CommitCallable.Report,
             CreateCollectionCallable.Report, 
@@ -168,7 +173,8 @@ public class AbstractReportFactory implements ReportFactory {
             CountCallable.Report, GetIndexSizeCallable.Report, 
             GetCollectionSizeCallable.Report, GetDocumentsSize.Report, 
             GetCollectionsMetainfoCallable.Report, MaxElementsCallable.Report,
-            CreatePathViewsCallable.Report, DropPathViewsCallable.Report {
+            CreatePathViewsCallable.Report, DropPathViewsCallable.Report,
+            SqlSelectCallable.Report {
 
         public static final DummyReport INSTANCE = new DummyReport();
 
@@ -280,6 +286,10 @@ public class AbstractReportFactory implements ReportFactory {
 
         @Override
         public void dropViewsExecuted(String collection) {
+        }
+
+        @Override
+        public void sqlSelectExecuted(String query) {
         }
 
     }

--- a/torod/db-executor/src/main/java/com/torodb/torod/db/executor/report/ReportFactory.java
+++ b/torod/db-executor/src/main/java/com/torodb/torod/db/executor/report/ReportFactory.java
@@ -58,4 +58,6 @@ public interface ReportFactory {
     public CreatePathViewsCallable.Report createCreatePathViewsReport();
 
     public DropPathViewsCallable.Report createDropPathViewsReport();
+
+    public SqlSelectCallable.Report createSqlSelectReport();
 }

--- a/torod/db-wrappers/postgresql/src/main/java/com/torodb/torod/db/sql/utils/SqlWindow.java
+++ b/torod/db-wrappers/postgresql/src/main/java/com/torodb/torod/db/sql/utils/SqlWindow.java
@@ -1,0 +1,209 @@
+
+package com.torodb.torod.db.sql.utils;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Sets;
+import com.torodb.torod.core.ValueRow;
+import com.torodb.torod.core.exceptions.ToroImplementationException;
+import com.torodb.torod.core.subdocument.BasicType;
+import com.torodb.torod.core.subdocument.values.NullValue;
+import com.torodb.torod.core.subdocument.values.Value;
+import com.torodb.torod.db.postgresql.converters.BasicTypeToSqlType;
+import com.torodb.torod.db.postgresql.converters.jooq.SubdocValueConverter;
+import com.torodb.torod.db.postgresql.converters.jooq.ValueToJooqConverterProvider;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nonnull;
+
+/**
+ *
+ */
+public class SqlWindow implements Iterator<ValueRow<Value>> {
+
+    private final Iterator<ValueRow<Value>> rows;
+
+    public SqlWindow(ResultSet rs) throws SQLException {
+        ResultSetMetaData metaData = rs.getMetaData();
+        final int columnLenght = metaData.getColumnCount();
+        
+        String[] columns = new String[columnLenght];
+        SubdocValueConverter[] converters = new SubdocValueConverter[columnLenght];
+
+        for (int i = 0; i < columnLenght; i++) {
+            
+            int jdbcIndex = i + 1; //result sets are 1-based instead of 0-based!
+            columns[i] = metaData.getColumnName(jdbcIndex);
+
+            BasicType basicType = getBasicType(metaData, jdbcIndex);
+
+            converters[i] = ValueToJooqConverterProvider.getConverter(basicType);
+        }
+
+        ImmutableList.Builder<ValueRow<Value>> builder = ImmutableList.builder();
+
+        while (rs.next()) {
+            Value[] values = new Value[columns.length];
+            for (int i = 0; i < columns.length; i++) {
+                int jdbcIndex = i+1;
+
+                Value value = readAndTransform(rs, jdbcIndex, converters[i]);
+                Preconditions.checkNotNull(value);
+                values[i] = value;
+            }
+            builder.add(new WindowValueRow(columns, values));
+        }
+        rows = builder.build().iterator();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return rows.hasNext();
+    }
+
+    @Override
+    public ValueRow<Value> next() {
+        return rows.next();
+    }
+
+    @Override
+    public void remove() {
+        rows.remove();
+    }
+
+    @Nonnull
+    private static Value readAndTransform(
+            ResultSet rs,
+            int jdbcIndex,
+            SubdocValueConverter converter) throws SQLException {
+        Object value;
+        switch (converter.getErasuredType()) {
+            case BOOLEAN:
+                value = rs.getBoolean(jdbcIndex);
+                break;
+            case DATETIME:
+                value = rs.getTimestamp(jdbcIndex);
+                break;
+            case DATE:
+                value = rs.getDate(jdbcIndex);
+                break;
+            case DOUBLE:
+                value = rs.getDouble(jdbcIndex);
+                break;
+            case INTEGER:
+                value = rs.getInt(jdbcIndex);
+                break;
+            case LONG:
+                value = rs.getLong(jdbcIndex);
+                break;
+            case NULL:
+                return NullValue.INSTANCE;
+            case ARRAY:
+            case PATTERN:
+            case STRING:
+                value = rs.getString(jdbcIndex);
+                break;
+
+            case TIME:
+                value = rs.getTime(jdbcIndex);
+                break;
+            case TWELVE_BYTES:
+                value = rs.getBytes(jdbcIndex);
+                break;
+            default:
+                throw new AssertionError("Unexpected basic type " + converter.getErasuredType());
+        }
+        if (value == null) {
+            return NullValue.INSTANCE;
+        }
+        return (Value) converter.from(value);
+    }
+
+    private static BasicType getBasicType(ResultSetMetaData metaData, int jdbcIndex) throws SQLException {
+        int columnType = metaData.getColumnType(jdbcIndex);
+        String columnTypeName = metaData.getColumnTypeName(jdbcIndex);
+        String columnName = metaData.getColumnName(jdbcIndex);
+
+        try {
+            return BasicTypeToSqlType.getInstance().toBasicType(
+                    columnName,
+                    columnType,
+                    columnTypeName
+            );
+        } catch (ToroImplementationException ex) {
+            if (columnTypeName.equals("bytea")) {
+                return BasicType.TWELVE_BYTES;
+            }
+            else {
+                throw ex;
+            }
+        }
+    }
+
+    private static class WindowValueRow implements ValueRow<Value> {
+
+        private final String[] columns;
+        private final Value[] values;
+
+        private WindowValueRow(@Nonnull String[] columns, @Nonnull Value[] values) {
+            this.columns = columns;
+            this.values = values;
+
+            Preconditions.checkArgument(columns.length == values.length);
+        }
+
+        @Override
+        public Set<Map.Entry<String, Value>> entrySet() {
+            HashSet<Map.Entry<String, Value>> result = new HashSet<>();
+            for (int i = 0; i < columns.length; i++) {
+                String column = columns[i];
+                Value value = values[i];
+                result.add(new SimpleEntry<>(column, value));
+            }
+            return result;
+        }
+
+        @Override
+        public Set<String> keySet() {
+            return Sets.newHashSet(Iterators.forArray(columns));
+        }
+
+        @Override
+        public Set<Value> valueSet() {
+            return Sets.newHashSet(Iterators.forArray(values));
+        }
+
+        @Override
+        public Value get(String key) throws IllegalArgumentException {
+            int searchResult = -1;
+            for (int i = 0; i < columns.length; i++) {
+                if (columns[i].equals(key)) {
+                    searchResult = i;
+                }
+            }
+            if (searchResult < 0) {
+                throw new IllegalArgumentException("The input '" + key + "' is not contained on this row");
+            }
+            return values[searchResult];
+        }
+
+        @Override
+        public void consume(ForEachConsumer<Value> consumer) {
+            for (int i = 0; i < columns.length; i++) {
+                String column = columns[i];
+                Value value = values[i];
+
+                consumer.consume(column, value);
+            }
+        }
+
+    }
+
+}

--- a/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/commands/ToroDBSpecificCommandTool.java
+++ b/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/commands/ToroDBSpecificCommandTool.java
@@ -5,8 +5,10 @@ import com.eightkdata.mongowp.mongoserver.api.safe.CommandImplementation;
 import com.google.common.collect.ImmutableMap;
 import com.torodb.torod.mongodb.commands.impl.torodb.CreatePathViewsImplementation;
 import com.torodb.torod.mongodb.commands.impl.torodb.DropPathViewsImplementation;
+import com.torodb.torod.mongodb.commands.impl.torodb.SqlSelectImplementation;
 import com.torodb.torod.mongodb.commands.torodb.CreatePathViewsCommand;
 import com.torodb.torod.mongodb.commands.torodb.DropPathViewsCommand;
+import com.torodb.torod.mongodb.commands.torodb.SqlSelectCommand;
 import javax.inject.Singleton;
 
 /**
@@ -21,6 +23,7 @@ public class ToroDBSpecificCommandTool {
         this.map = ImmutableMap.<Command, CommandImplementation>builder()
                 .put(CreatePathViewsCommand.INSTANCE, new CreatePathViewsImplementation())
                 .put(DropPathViewsCommand.INSTANCE, new DropPathViewsImplementation())
+                .put(SqlSelectCommand.INSTANCE, new SqlSelectImplementation())
                 .build();
     }
 

--- a/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/commands/impl/torodb/SqlSelectImplementation.java
+++ b/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/commands/impl/torodb/SqlSelectImplementation.java
@@ -1,0 +1,121 @@
+
+package com.torodb.torod.mongodb.commands.impl.torodb;
+
+import com.eightkdata.mongowp.mongoserver.api.safe.Command;
+import com.eightkdata.mongowp.mongoserver.api.safe.CommandRequest;
+import com.eightkdata.mongowp.mongoserver.api.safe.CommandResult;
+import com.eightkdata.mongowp.mongoserver.api.safe.impl.NonWriteCommandResult;
+import com.eightkdata.mongowp.mongoserver.api.safe.library.v3m0.tools.CursorMarshaller.FirstBatchOnlyCursor;
+import com.eightkdata.mongowp.mongoserver.api.safe.pojos.MongoCursor;
+import com.eightkdata.mongowp.mongoserver.protocol.exceptions.CommandFailed;
+import com.eightkdata.mongowp.mongoserver.protocol.exceptions.InternalErrorException;
+import com.eightkdata.mongowp.mongoserver.protocol.exceptions.MongoException;
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
+import com.torodb.kvdocument.conversion.mongo.MongoValueConverter;
+import com.torodb.kvdocument.values.DocValue;
+import com.torodb.torod.core.ValueRow;
+import com.torodb.torod.core.ValueRow.ForEachConsumer;
+import com.torodb.torod.core.connection.ToroConnection;
+import com.torodb.torod.core.connection.ToroTransaction;
+import com.torodb.torod.core.dbWrapper.exceptions.ImplementationDbException;
+import com.torodb.torod.mongodb.RequestContext;
+import com.torodb.torod.mongodb.commands.AbstractToroCommandImplementation;
+import com.torodb.torod.mongodb.commands.torodb.SqlSelectCommand.SqlSelectArgument;
+import com.torodb.torod.mongodb.commands.torodb.SqlSelectCommand.SqlSelectResult;
+import com.torodb.torod.mongodb.utils.ToroDBThrowables;
+import java.util.Iterator;
+import javax.annotation.Nonnull;
+import org.bson.BsonDocument;
+import org.bson.BsonValue;
+
+/**
+ *
+ */
+public class SqlSelectImplementation extends
+        AbstractToroCommandImplementation<SqlSelectArgument, SqlSelectResult> {
+
+    private static final ValueRowToBsonDocument TRANSLATE_FUNCTION = new ValueRowToBsonDocument();
+
+    @Override
+    public CommandResult<SqlSelectResult> apply(
+            Command<? super SqlSelectArgument, ? super SqlSelectResult> command,
+            CommandRequest<SqlSelectArgument> req) throws MongoException {
+
+        RequestContext context = RequestContext.getFrom(req);
+        String supportedDatabase = context.getSupportedDatabase();
+
+        String commandName = command.getCommandName();
+        SqlSelectArgument arg = req.getCommandArgument();
+
+        if (!supportedDatabase.equals(req.getDatabase())) {
+            throw new CommandFailed(
+                    commandName,
+                    "Database '"+req.getDatabase()+"' is not supported. "
+                            + "Only '" + supportedDatabase +"' is supported");
+        }
+
+        ToroConnection connection = context.getToroConnection();
+        ToroTransaction transaction = null;
+
+        try {
+            transaction = connection.createTransaction();
+            Iterator<ValueRow<DocValue>> toroQueryResult = ToroDBThrowables.getFromCommand(
+                    commandName,
+                    transaction.sqlSelect(arg.getQuery())
+            );
+            ToroDBThrowables.getFromCommand(commandName, transaction.commit());
+
+            ImmutableList<BsonDocument> queryResult = ImmutableList.copyOf(
+                    Iterators.transform(
+                            toroQueryResult,
+                            TRANSLATE_FUNCTION
+                    )
+            );
+
+            MongoCursor<BsonDocument> cursor = new FirstBatchOnlyCursor<>(
+                    0,
+                    req.getDatabase(),
+                    arg.getCollection(),
+                    queryResult,
+                    System.currentTimeMillis()
+            );
+
+            return new NonWriteCommandResult<>(new SqlSelectResult(cursor));
+        } catch (ImplementationDbException ex) {
+            throw new InternalErrorException(command.getCommandName(), ex);
+        } finally {
+            if (transaction != null) {
+                transaction.close();
+            }
+        }
+
+    }
+
+    private static class ValueRowToBsonDocument implements 
+            Function<ValueRow<DocValue>, BsonDocument> {
+
+        @Override
+        public BsonDocument apply(@Nonnull ValueRow<DocValue> input) {
+
+            Collector collector = new Collector();
+
+            input.consume(collector);
+            return collector.doc;
+        }
+
+        private static class Collector implements ForEachConsumer<DocValue> {
+
+            private final BsonDocument doc = new BsonDocument();
+
+            @Override
+            public void consume(String key, DocValue value) {
+                BsonValue translated = MongoValueConverter.translateDocValue(value);
+                doc.append(key, translated);
+            }
+        }
+
+    }
+
+}

--- a/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/commands/torodb/SqlSelectCommand.java
+++ b/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/commands/torodb/SqlSelectCommand.java
@@ -1,0 +1,167 @@
+
+package com.torodb.torod.mongodb.commands.torodb;
+
+import com.eightkdata.mongowp.mongoserver.api.safe.MarshalException;
+import com.eightkdata.mongowp.mongoserver.api.safe.impl.AbstractCommand;
+import com.eightkdata.mongowp.mongoserver.api.safe.library.v3m0.tools.CursorMarshaller;
+import com.eightkdata.mongowp.mongoserver.api.safe.pojos.MongoCursor;
+import com.eightkdata.mongowp.mongoserver.api.safe.tools.bson.BsonDocumentBuilder;
+import com.eightkdata.mongowp.mongoserver.api.safe.tools.bson.BsonField;
+import com.eightkdata.mongowp.mongoserver.api.safe.tools.bson.BsonReaderTool;
+import com.eightkdata.mongowp.mongoserver.protocol.exceptions.*;
+import com.google.common.annotations.Beta;
+import com.google.common.base.Function;
+import com.torodb.torod.mongodb.commands.torodb.SqlSelectCommand.SqlSelectArgument;
+import com.torodb.torod.mongodb.commands.torodb.SqlSelectCommand.SqlSelectResult;
+import javax.annotation.Nonnull;
+import org.bson.BsonDocument;
+import org.bson.BsonValue;
+
+/**
+ *
+ */
+@Beta
+public class SqlSelectCommand extends AbstractCommand<SqlSelectArgument, SqlSelectResult> {
+
+    private static final String COMMAND_NAME = "sql-select";
+    public static final SqlSelectCommand INSTANCE = new SqlSelectCommand();
+
+    private SqlSelectCommand() {
+        super(COMMAND_NAME);
+    }
+
+    @Override
+    public Class<? extends SqlSelectArgument> getArgClass() {
+        return SqlSelectArgument.class;
+    }
+
+    @Override
+    public SqlSelectArgument unmarshallArg(BsonDocument requestDoc)
+            throws BadValueException, TypesMismatchException, NoSuchKeyException,
+            FailedToParseException {
+        return SqlSelectArgument.unmarshall(requestDoc);
+    }
+
+    @Override
+    public BsonDocument marshallArg(SqlSelectArgument request) throws
+            MarshalException {
+        return request.marshall();
+    }
+
+    @Override
+    public Class<? extends SqlSelectResult> getResultClass() {
+        return SqlSelectResult.class;
+    }
+
+    @Override
+    public SqlSelectResult unmarshallResult(BsonDocument resultDoc) throws
+            BadValueException, TypesMismatchException, NoSuchKeyException,
+            FailedToParseException, MongoException {
+        return SqlSelectResult.unmarshall(resultDoc);
+    }
+
+    @Override
+    public BsonDocument marshallResult(SqlSelectResult result) throws MarshalException {
+        return result.marshall();
+    }
+
+    public static class SqlSelectArgument {
+
+        private static final BsonField<String> COLLECTION_FIELD = BsonField.create(COMMAND_NAME);
+        private static final BsonField<String> QUERY_FIELD = BsonField.create("query");
+
+        private final String collection;
+        private final String query;
+
+        public SqlSelectArgument(String collection, String query) {
+            this.collection = collection;
+            this.query = query;
+        }
+
+        public String getCollection() {
+            return collection;
+        }
+
+        public String getQuery() {
+            return query;
+        }
+
+        private static SqlSelectArgument unmarshall(BsonDocument requestDoc) 
+                throws TypesMismatchException, NoSuchKeyException {
+            String collection = BsonReaderTool.getString(requestDoc, COLLECTION_FIELD);
+            String query = BsonReaderTool.getString(requestDoc, QUERY_FIELD);
+            return new SqlSelectArgument(collection, query);
+        }
+
+        private BsonDocument marshall() {
+            return new BsonDocumentBuilder()
+                    .append(COLLECTION_FIELD, collection)
+                    .append(QUERY_FIELD, query)
+                    .build();
+        }
+        
+    }
+
+    public static class SqlSelectResult {
+
+        private static final BsonField<BsonDocument> CURSOR_FIELD = BsonField.create("cursor");
+        private static final ToBsonFunction TO_BSON = new ToBsonFunction();
+        private static final FromBsonFunction FROM_BSON = new FromBsonFunction();
+        private static final BsonField<String> BETA_FIELD = BsonField.create("betaCmd");
+
+        private final MongoCursor<BsonDocument> cursor;
+
+        public SqlSelectResult(MongoCursor<BsonDocument> cursor) {
+            this.cursor = cursor;
+        }
+
+        public MongoCursor<BsonDocument> getCursor() {
+            return cursor;
+        }
+
+        private static SqlSelectResult unmarshall(BsonDocument resultDoc)
+                throws TypesMismatchException, NoSuchKeyException, BadValueException {
+            BsonDocument cursorDoc = BsonReaderTool.getDocument(resultDoc, CURSOR_FIELD);
+
+            return new SqlSelectResult(
+                    CursorMarshaller.unmarshall(cursorDoc, TO_BSON)
+            );
+        }
+
+        private BsonDocument marshall() throws MarshalException {
+            BsonDocumentBuilder builder = new BsonDocumentBuilder();
+
+            try {
+                return builder
+                        .append(CURSOR_FIELD, CursorMarshaller.marshall(cursor, FROM_BSON))
+                        .append(BETA_FIELD, "This is a beta command")
+                        .build();
+            } catch (MongoException ex) {
+                throw new MarshalException(ex);
+            }
+        }
+
+        private static class ToBsonFunction implements Function<BsonValue, BsonDocument> {
+
+            @Override
+            public BsonDocument apply(@Nonnull BsonValue input) {
+                if (input instanceof BsonDocument) {
+                    return (BsonDocument) input;
+                }
+                throw new IllegalArgumentException("");
+            }
+
+        }
+
+        private static class FromBsonFunction implements Function<BsonDocument, BsonValue> {
+
+            @Override
+            public BsonValue apply(BsonDocument input) {
+                return input;
+            }
+
+        }
+
+    }
+
+}

--- a/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/srp/DatabaseCheckSafeRequestProcessor.java
+++ b/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/srp/DatabaseCheckSafeRequestProcessor.java
@@ -1,7 +1,9 @@
 
 package com.torodb.torod.mongodb.srp;
 
-import com.eightkdata.mongowp.messages.request.*;
+import com.eightkdata.mongowp.messages.request.DeleteMessage;
+import com.eightkdata.mongowp.messages.request.InsertMessage;
+import com.eightkdata.mongowp.messages.request.UpdateMessage;
 import com.eightkdata.mongowp.messages.response.ReplyMessage;
 import com.eightkdata.mongowp.mongoserver.api.safe.*;
 import com.eightkdata.mongowp.mongoserver.api.safe.impl.UpdateOpResult;
@@ -51,6 +53,7 @@ public class DatabaseCheckSafeRequestProcessor extends DecoratorSafeRequestProce
     private void checkDatabase(String database) throws DatabaseNotFoundException {
         if (!isAllowed(database)) {
             throw new DatabaseNotFoundException(
+                    database,
                     "Database '" + database + "' is not supported. "
                     + "Only '" + supportedDatabase +"' is supported");
         }

--- a/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/utils/ToroDBThrowables.java
+++ b/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/utils/ToroDBThrowables.java
@@ -3,6 +3,7 @@ package com.torodb.torod.mongodb.utils;
 
 import com.eightkdata.mongowp.mongoserver.protocol.exceptions.CommandFailed;
 import com.torodb.torod.core.exceptions.ToroException;
+import com.torodb.torod.core.exceptions.UserToroException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import org.slf4j.Logger;
@@ -28,7 +29,7 @@ public class ToroDBThrowables {
             throw new CommandFailed(commandName, "Interrupted while executing");
         } catch (ExecutionException ex) {
             Throwable cause = ex.getCause();
-            if (cause != null && cause instanceof ToroException) {
+            if (cause != null && (cause instanceof ToroException || cause instanceof UserToroException)) {
                 throw new CommandFailed(commandName, cause.getLocalizedMessage());
             }
             LOGGER.warn("Internal error while executing " + commandName, ex);

--- a/torod/torod-core/src/main/java/com/torodb/torod/core/ValueRow.java
+++ b/torod/torod-core/src/main/java/com/torodb/torod/core/ValueRow.java
@@ -1,0 +1,110 @@
+
+package com.torodb.torod.core;
+
+import com.google.common.base.Function;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import javax.annotation.Nonnull;
+
+/**
+ *
+ */
+public interface ValueRow<V> {
+
+    public Set<Map.Entry<String, V>> entrySet();
+
+    public Set<String> keySet();
+
+    public Set<V> valueSet();
+
+    @Nonnull
+    public V get(String key) throws IllegalArgumentException;
+
+    public void consume(ForEachConsumer<V> consumer);
+
+    public static interface ForEachConsumer<V> {
+        public void consume(String key, V value);
+    }
+
+    public static class TranslatorValueRow<I,O> implements ValueRow<O> {
+        private final Function<I, O> function;
+        private final ValueRow<I> innerRow;
+
+        public TranslatorValueRow(ValueRow<I> innerRow, Function<I, O> function) {
+            this.function = function;
+            this.innerRow = innerRow;
+        }
+
+        @Override
+        public Set<Entry<String, O>> entrySet() {
+            Set<Entry<String, I>> innerSet = innerRow.entrySet();
+            Set<Entry<String, O>> result = new HashSet<>(innerSet.size());
+            for (Entry<String, I> entry : innerSet) {
+                result.add(new SimpleEntry<>(entry.getKey(), function.apply(entry.getValue())));
+            }
+            return result;
+        }
+
+        @Override
+        public Set<String> keySet() {
+            return innerRow.keySet();
+        }
+
+        @Override
+        public Set<O> valueSet() {
+            Set<I> innerSet = innerRow.valueSet();
+            Set<O> result = new HashSet<>(innerSet.size());
+            for (I innerValue : innerSet) {
+                result.add(function.apply(innerValue));
+            }
+            return result;
+        }
+
+        @Override
+        public O get(String key) throws IllegalArgumentException {
+            return function.apply(innerRow.get(key));
+        }
+
+        @Override
+        public void consume(ForEachConsumer<O> consumer) {
+            innerRow.consume(new ConsumerTranslator(consumer));
+        }
+
+        public static <I2,O2> Function<ValueRow<I2>, ValueRow<O2>> getBuilderFunction(Function<I2, O2> function) {
+            return new BuilderFunction<>(function);
+        }
+
+        private static class BuilderFunction<I2, O2> implements Function<ValueRow<I2>, ValueRow<O2>> {
+
+            private final Function<I2, O2> function;
+
+            private BuilderFunction(Function<I2, O2> function) {
+                this.function = function;
+            }
+
+            @Override
+            public ValueRow<O2> apply(ValueRow<I2> input) {
+                return new TranslatorValueRow<>(input, function);
+            }
+
+        }
+
+        private class ConsumerTranslator implements ForEachConsumer<I> {
+
+            private final ForEachConsumer<O> outerConsummer;
+
+            private ConsumerTranslator(ForEachConsumer<O> outerConsummer) {
+                this.outerConsummer = outerConsummer;
+            }
+
+            @Override
+            public void consume(String key, I value) {
+                outerConsummer.consume(key, function.apply(value));
+            }
+
+        }
+    }
+}

--- a/torod/torod-core/src/main/java/com/torodb/torod/core/connection/ToroTransaction.java
+++ b/torod/torod-core/src/main/java/com/torodb/torod/core/connection/ToroTransaction.java
@@ -22,8 +22,11 @@ package com.torodb.torod.core.connection;
 
 import com.google.common.annotations.Beta;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.torodb.kvdocument.values.DocValue;
+import com.torodb.torod.core.ValueRow;
 import com.torodb.torod.core.WriteFailMode;
 import com.torodb.torod.core.exceptions.ExistentIndexException;
+import com.torodb.torod.core.exceptions.UserToroException;
 import com.torodb.torod.core.language.operations.DeleteOperation;
 import com.torodb.torod.core.language.operations.UpdateOperation;
 import com.torodb.torod.core.language.querycriteria.QueryCriteria;
@@ -33,6 +36,7 @@ import com.torodb.torod.core.pojos.NamedToroIndex;
 import com.torodb.torod.core.subdocument.ToroDocument;
 import java.io.Closeable;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.Future;
 import javax.annotation.Nonnull;
@@ -132,4 +136,7 @@ public interface ToroTransaction extends Closeable {
 
     @Beta
     public ListenableFuture<Void> dropPathViews(String collection) throws UnsupportedOperationException;
+
+    @Beta
+    public ListenableFuture<Iterator<ValueRow<DocValue>>> sqlSelect(String sqlQuery) throws UnsupportedOperationException, UserToroException;
 }

--- a/torod/torod-core/src/main/java/com/torodb/torod/core/dbWrapper/DbConnection.java
+++ b/torod/torod-core/src/main/java/com/torodb/torod/core/dbWrapper/DbConnection.java
@@ -21,9 +21,11 @@
 package com.torodb.torod.core.dbWrapper;
 
 import com.google.common.annotations.Beta;
+import com.torodb.torod.core.ValueRow;
 import com.torodb.torod.core.dbWrapper.exceptions.ImplementationDbException;
 import com.torodb.torod.core.dbWrapper.exceptions.UserDbException;
 import com.torodb.torod.core.exceptions.IllegalPathViewException;
+import com.torodb.torod.core.exceptions.UserToroException;
 import com.torodb.torod.core.language.querycriteria.QueryCriteria;
 import com.torodb.torod.core.pojos.CollectionMetainfo;
 import com.torodb.torod.core.pojos.IndexedAttributes;
@@ -31,6 +33,7 @@ import com.torodb.torod.core.pojos.NamedToroIndex;
 import com.torodb.torod.core.subdocument.SplitDocument;
 import com.torodb.torod.core.subdocument.SubDocType;
 import com.torodb.torod.core.subdocument.SubDocument;
+import com.torodb.torod.core.subdocument.values.Value;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -173,4 +176,6 @@ public interface DbConnection {
 
     @Beta
     public void dropPathViews(String collection) throws IllegalPathViewException;
+
+    public Iterator<ValueRow<Value>> select(String query) throws UserToroException;
 }

--- a/torod/torod-core/src/main/java/com/torodb/torod/core/executor/SessionTransaction.java
+++ b/torod/torod-core/src/main/java/com/torodb/torod/core/executor/SessionTransaction.java
@@ -22,17 +22,21 @@ package com.torodb.torod.core.executor;
 
 import com.google.common.annotations.Beta;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.torodb.torod.core.ValueRow;
 import com.torodb.torod.core.WriteFailMode;
 import com.torodb.torod.core.connection.DeleteResponse;
 import com.torodb.torod.core.connection.InsertResponse;
+import com.torodb.torod.core.exceptions.UserToroException;
 import com.torodb.torod.core.language.operations.DeleteOperation;
 import com.torodb.torod.core.language.querycriteria.QueryCriteria;
 import com.torodb.torod.core.pojos.Database;
 import com.torodb.torod.core.pojos.IndexedAttributes;
 import com.torodb.torod.core.pojos.NamedToroIndex;
 import com.torodb.torod.core.subdocument.SplitDocument;
+import com.torodb.torod.core.subdocument.values.Value;
 import java.io.Closeable;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import javax.annotation.Nonnull;
 
@@ -105,4 +109,7 @@ public interface SessionTransaction extends Closeable {
 
     @Beta
     public ListenableFuture<Void> dropPathViews(String collection);
+
+    @Beta
+    public ListenableFuture<Iterator<ValueRow<Value>>> sqlSelect(String sqlQuery) throws UserToroException;
 }

--- a/torodb/hs_err_pid14077.log
+++ b/torodb/hs_err_pid14077.log
@@ -1,0 +1,899 @@
+#
+# A fatal error has been detected by the Java Runtime Environment:
+#
+#  SIGSEGV (0xb) at pc=0x00007fb9d8819800, pid=14077, tid=140434693158656
+#
+# JRE version: Java(TM) SE Runtime Environment (8.0_66-b17) (build 1.8.0_66-b17)
+# Java VM: Java HotSpot(TM) 64-Bit Server VM (25.66-b17 mixed mode linux-amd64 compressed oops)
+# Problematic frame:
+# V  [libjvm.so+0x8a5800]  Method::checked_resolve_jmethod_id(_jmethodID*)+0x20
+#
+# Failed to write core dump. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
+#
+# If you would like to submit a bug report, please visit:
+#   http://bugreport.java.com/bugreport/crash.jsp
+#
+
+---------------  T H R E A D  ---------------
+
+Current thread (0x00007fb9d0150000):  JavaThread "JDWP Transport Listener: dt_socket" daemon [_thread_in_vm, id=14099, stack(0x00007fb97feff000,0x00007fb980000000)]
+
+siginfo: si_signo: 11 (SIGSEGV), si_code: 128 (SI_KERNEL), si_addr: 0x0000000000000000
+
+Registers:
+RAX=0x0000000000000001, RBX=0x00007fb9d0005220, RCX=0x00007fb9d994b340, RDX=0x00007fb9d8f23560
+RSP=0x00007fb97fffe7d0, RBP=0x00007fb97fffe7e0, RSI=0x00007fb9d0150000, RDI=0x003b79003b747369
+R8 =0x00007fb9740042b0, R9 =0x0000000000000000, R10=0x0000000000000010, R11=0x00007fb9d90d5280
+R12=0x0000000000000017, R13=0x003b79003b747369, R14=0x00007fb9d0150000, R15=0x00007fb97fffe8e7
+RIP=0x00007fb9d8819800, EFLAGS=0x0000000000010206, CSGSFS=0x0000000000000033, ERR=0x0000000000000000
+  TRAPNO=0x000000000000000d
+
+Top of Stack: (sp=0x00007fb97fffe7d0)
+0x00007fb97fffe7d0:   0000000000000074 00007fb9d0005220
+0x00007fb97fffe7e0:   00007fb97fffe850 00007fb9d86aa2de
+0x00007fb97fffe7f0:   00007fb97fffe810 00007fb97fffe800
+0x00007fb97fffe800:   00007fb9d0150000 0000000000000000
+0x00007fb97fffe810:   00007fb900000000 0000000000000000
+0x00007fb97fffe820:   00007fb97fffe840 00007fb9d7628e40
+0x00007fb97fffe830:   003b79003b747369 00007fb97fffe8e7
+0x00007fb97fffe840:   0000000000000006 00007fb97fffe8e7
+0x00007fb97fffe850:   00007fb97fffe880 00007fb9d74148c2
+0x00007fb97fffe860:   00007fb97fffe880 003b79003b747369
+0x00007fb97fffe870:   00007fb97fffe950 0000000000000030
+0x00007fb97fffe880:   00007fb97fffe910 00007fb9d73f5aa0
+0x00007fb97fffe890:   00007fb97fffe8c8 00007fb97fffe8c0
+0x00007fb97fffe8a0:   00007fb97fffe8b8 00007fb97fffe8dc
+0x00007fb97fffe8b0:   0000000174003830 0000000000000000
+0x00007fb97fffe8c0:   0000000000000000 0000000000000000
+0x00007fb97fffe8d0:   00007fb9740033a0 f00010417fffe950
+0x00007fb97fffe8e0:   0100000000000007 0000000000000002
+0x00007fb97fffe8f0:   000000000000000f 0000000000000002
+0x00007fb97fffe900:   00000000000f0200 000000000000000f
+0x00007fb97fffe910:   00007fb97fffeb60 00007fb9d74009c6
+0x00007fb97fffe920:   000144d200000013 00007fb9d80f0200
+0x00007fb97fffe930:   00007fb970000fb0 0000000000000000
+0x00007fb97fffe940:   00007fb97fffe950 00007fb97fffeae0
+0x00007fb97fffe950:   00007fb97400f881 00007fb900000157
+0x00007fb97fffe960:   00007fb9740042d0 000000000000012c
+0x00007fb97fffe970:   00007fb97fffe9a0 00007fb9740042d0
+0x00007fb97fffe980:   00007f0000000000 000144d20000000c
+0x00007fb97fffe990:   00007fb90000ea80 00007fb97fffe9a0
+0x00007fb97fffe9a0:   b97f000007000000 0c00000018400074
+0x00007fb97fffe9b0:   6369736142746567 4c00000065707954
+0x00007fb97fffe9c0:   732f6176616a4c28 6c757365522f6c71 
+
+Instructions: (pc=0x00007fb9d8819800)
+0x00007fb9d88197e0:   55 48 89 e5 53 48 83 ec 08 48 85 ff 75 12 31 db
+0x00007fb9d88197f0:   48 89 d8 48 83 c4 08 5b c9 c3 66 0f 1f 44 00 00
+0x00007fb9d8819800:   48 8b 1f 48 85 db 74 e6 48 83 fb 37 74 e0 48 8b
+0x00007fb9d8819810:   03 48 89 df ff 50 10 84 c0 0f 1f 80 00 00 00 00 
+
+Register to memory mapping:
+
+RAX=0x0000000000000001 is an unknown value
+RBX=0x00007fb9d0005220 is an unknown value
+RCX=0x00007fb9d994b340: <offset 0x219340> in /lib/x86_64-linux-gnu/libpthread.so.0 at 0x00007fb9d9732000
+RDX=0x00007fb9d8f23560: <offset 0xfaf560> in /usr/lib/jvm/java-8-oracle/jre/lib/amd64/server/libjvm.so at 0x00007fb9d7f74000
+RSP=0x00007fb97fffe7d0 is pointing into the stack for thread: 0x00007fb9d0150000
+RBP=0x00007fb97fffe7e0 is pointing into the stack for thread: 0x00007fb9d0150000
+RSI=0x00007fb9d0150000 is a thread
+RDI=0x003b79003b747369 is an unknown value
+R8 =0x00007fb9740042b0 is an unknown value
+R9 =0x0000000000000000 is an unknown value
+R10=0x0000000000000010 is an unknown value
+R11=0x00007fb9d90d5280: <offset 0x187280> in /lib/x86_64-linux-gnu/libc.so.6 at 0x00007fb9d8f4e000
+R12=0x0000000000000017 is an unknown value
+R13=0x003b79003b747369 is an unknown value
+R14=0x00007fb9d0150000 is a thread
+R15=0x00007fb97fffe8e7 is pointing into the stack for thread: 0x00007fb9d0150000
+
+
+Stack: [0x00007fb97feff000,0x00007fb980000000],  sp=0x00007fb97fffe7d0,  free space=1021k
+Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
+V  [libjvm.so+0x8a5800]  Method::checked_resolve_jmethod_id(_jmethodID*)+0x20
+V  [libjvm.so+0x7362de]  jvmti_IsMethodSynthetic+0x2be
+C  [libjdwp.so+0x258c2]  isMethodSynthetic+0x42
+C  [libjdwp.so+0x6aa0]  methods1+0x1b0
+C  [libjdwp.so+0x119c6]  debugLoop_run+0x2b6
+C  [libjdwp.so+0x247ff]  attachThread+0x2f
+V  [libjvm.so+0x7a2a62]  JvmtiAgentThread::call_start_function()+0xc2
+V  [libjvm.so+0xa68fff]  JavaThread::thread_main_inner()+0xdf
+V  [libjvm.so+0xa6912c]  JavaThread::run()+0x11c
+V  [libjvm.so+0x91cc68]  java_start(Thread*)+0x108
+C  [libpthread.so.0+0x76aa]  start_thread+0xca
+
+
+---------------  P R O C E S S  ---------------
+
+Java Threads: ( => current thread )
+  0x00007fb924457800 JavaThread "torod-session-4" [_thread_blocked, id=14206, stack(0x00007fb97dc8a000,0x00007fb97dd8b000)]
+  0x00007fb92000a800 JavaThread "nioEventLoopGroup-3-1" [_thread_in_native, id=14205, stack(0x00007fb97d684000,0x00007fb97d785000)]
+  0x00007fb924be9800 JavaThread "nioEventLoopGroup-2-1" [_thread_in_native, id=14198, stack(0x00007fb97c8e0000,0x00007fb97c9e1000)]
+  0x00007fb924869000 JavaThread "torod-system-1" [_thread_blocked, id=14192, stack(0x00007fb97d0e2000,0x00007fb97d1e3000)]
+  0x00007fb924868000 JavaThread "wait-submit" [_thread_blocked, id=14191, stack(0x00007fb97d785000,0x00007fb97d886000)]
+  0x00007fb9d000e000 JavaThread "DestroyJavaVM" [_thread_blocked, id=14078, stack(0x00007fb9d9a3f000,0x00007fb9d9b40000)]
+  0x00007fb9d0ae1800 JavaThread "Hikari Housekeeping Timer (pool cursors)" daemon [_thread_blocked, id=14138, stack(0x00007fb97db89000,0x00007fb97dc8a000)]
+  0x00007fb9d0ae3000 JavaThread "Hikari Housekeeping Timer (pool system)" daemon [_thread_blocked, id=14130, stack(0x00007fb97da88000,0x00007fb97db89000)]
+  0x00007fb9d0a75000 JavaThread "PostgreSQL-JDBC-SharedTimer-1" daemon [_thread_blocked, id=14125, stack(0x00007fb97dd8b000,0x00007fb97de8c000)]
+  0x00007fb9d0a6e000 JavaThread "Hikari Housekeeping Timer (pool session)" daemon [_thread_blocked, id=14122, stack(0x00007fb97de8c000,0x00007fb97df8d000)]
+  0x00007fb9d02bc800 JavaThread "Service Thread" daemon [_thread_blocked, id=14111, stack(0x00007fb97eac6000,0x00007fb97ebc7000)]
+  0x00007fb9d02f7800 JavaThread "C1 CompilerThread3" daemon [_thread_blocked, id=14110, stack(0x00007fb97ebc7000,0x00007fb97ecc8000)]
+  0x00007fb9d02f5000 JavaThread "C2 CompilerThread2" daemon [_thread_blocked, id=14109, stack(0x00007fb97ecc8000,0x00007fb97edc9000)]
+  0x00007fb9d02f3000 JavaThread "C2 CompilerThread1" daemon [_thread_blocked, id=14108, stack(0x00007fb97edc9000,0x00007fb97eeca000)]
+  0x00007fb9d02eb800 JavaThread "C2 CompilerThread0" daemon [_thread_blocked, id=14107, stack(0x00007fb97eeca000,0x00007fb97efcb000)]
+  0x00007fb9d02ea000 JavaThread "VM JFR Buffer Thread" daemon [_thread_blocked, id=14106, stack(0x00007fb97efcb000,0x00007fb97f0cc000)]
+  0x00007fb9d015d000 JavaThread "JFR request timer" daemon [_thread_blocked, id=14105, stack(0x00007fb97f9f7000,0x00007fb97faf8000)]
+  0x00007fb974001000 JavaThread "JDWP Command Reader" daemon [_thread_in_native, id=14103, stack(0x00007fb97fcfd000,0x00007fb97fdfe000)]
+  0x00007fb9d0153800 JavaThread "JDWP Event Helper Thread" daemon [_thread_blocked, id=14102, stack(0x00007fb97fdfe000,0x00007fb97feff000)]
+=>0x00007fb9d0150000 JavaThread "JDWP Transport Listener: dt_socket" daemon [_thread_in_vm, id=14099, stack(0x00007fb97feff000,0x00007fb980000000)]
+  0x00007fb9d0142800 JavaThread "Signal Dispatcher" daemon [_thread_blocked, id=14098, stack(0x00007fb9a02c8000,0x00007fb9a03c9000)]
+  0x00007fb9d0141000 JavaThread "Surrogate Locker Thread (Concurrent GC)" daemon [_thread_blocked, id=14097, stack(0x00007fb9a03c9000,0x00007fb9a04ca000)]
+  0x00007fb9d00f7800 JavaThread "Finalizer" daemon [_thread_blocked, id=14096, stack(0x00007fb9a0f08000,0x00007fb9a1009000)]
+  0x00007fb9d00f5800 JavaThread "Reference Handler" daemon [_thread_blocked, id=14095, stack(0x00007fb9a1009000,0x00007fb9a110a000)]
+
+Other Threads:
+  0x00007fb9d00f0000 VMThread [stack: 0x00007fb9a110a000,0x00007fb9a120b000] [id=14094]
+  0x00007fb9d02c0000 WatcherThread [stack: 0x00007fb97e9c5000,0x00007fb97eac6000] [id=14112]
+
+VM state:not at safepoint (normal execution)
+
+VM Mutex/Monitor currently owned by a thread: None
+
+Heap:
+ par new generation   total 92160K, used 48791K [0x00000000a2400000, 0x00000000a8800000, 0x00000000c1800000)
+  eden space 81920K,  49% used [0x00000000a2400000, 0x00000000a4be3018, 0x00000000a7400000)
+  from space 10240K,  77% used [0x00000000a7400000, 0x00000000a7bc2cd8, 0x00000000a7e00000)
+  to   space 10240K,   0% used [0x00000000a7e00000, 0x00000000a7e00000, 0x00000000a8800000)
+ concurrent mark-sweep generation total 204800K, used 3419K [0x00000000c1800000, 0x00000000ce000000, 0x0000000100000000)
+ Metaspace       used 31268K, capacity 31560K, committed 31948K, reserved 1077248K
+  class space    used 3619K, capacity 3725K, committed 3788K, reserved 1048576K
+
+Card table byte_map: [0x00007fb9d539f000,0x00007fb9d568e000] byte_map_base: 0x00007fb9d4e8d000
+
+Marking Bits: (CMSBitMap*) 0x00007fb9d00981e8
+ Bits: [0x00007fb9c005f000, 0x00007fb9c0fff000)
+
+Mod Union Table: (CMSBitMap*) 0x00007fb9d00982a8
+ Bits: [0x00007fb9d9a00000, 0x00007fb9d9a3e800)
+
+Polling page: 0x00007fb9d9b70000
+
+CodeCache: size=245760Kb used=9262Kb max_used=9289Kb free=236497Kb
+ bounds [0x00007fb9c1000000, 0x00007fb9c1920000, 0x00007fb9d0000000]
+ total_blobs=2982 nmethods=2540 adapters=363
+ compilation: enabled
+
+Compilation events (10 events):
+Event: 257,197 Thread 0x00007fb9d02f7800 2596       3       io.netty.util.concurrent.SingleThreadEventExecutor::delayNanos (19 bytes)
+Event: 257,197 Thread 0x00007fb9d02f7800 nmethod 2596 0x00007fb9c112e990 code [0x00007fb9c112eb40, 0x00007fb9c112f288]
+Event: 257,197 Thread 0x00007fb9d02f7800 2597       3       io.netty.util.concurrent.AbstractScheduledEventExecutor::peekScheduledTask (21 bytes)
+Event: 257,197 Thread 0x00007fb9d02f7800 nmethod 2597 0x00007fb9c112e350 code [0x00007fb9c112e4e0, 0x00007fb9c112e848]
+Event: 257,197 Thread 0x00007fb9d02f7800 2598       3       sun.nio.ch.SelectorImpl::select (34 bytes)
+Event: 257,197 Thread 0x00007fb9d02f7800 nmethod 2598 0x00007fb9c11189d0 code [0x00007fb9c1118b60, 0x00007fb9c1118e78]
+Event: 271,756 Thread 0x00007fb9d02f7800 2599       3       com.zaxxer.hikari.util.ConcurrentBag::reserve (13 bytes)
+Event: 271,756 Thread 0x00007fb9d02f7800 nmethod 2599 0x00007fb9c113f710 code [0x00007fb9c113f880, 0x00007fb9c113fb30]
+Event: 271,756 Thread 0x00007fb9d02f7800 2600       3       com.zaxxer.hikari.util.ConcurrentBag::unreserve (50 bytes)
+Event: 271,757 Thread 0x00007fb9d02f7800 nmethod 2600 0x00007fb9c113ea10 code [0x00007fb9c113ebe0, 0x00007fb9c113f3b8]
+
+GC Heap History (4 events):
+Event: 1,426 GC heap before
+{Heap before GC invocations=0 (full 0):
+ par new generation   total 92160K, used 81920K [0x00000000a2400000, 0x00000000a8800000, 0x00000000c1800000)
+  eden space 81920K, 100% used [0x00000000a2400000, 0x00000000a7400000, 0x00000000a7400000)
+  from space 10240K,   0% used [0x00000000a7400000, 0x00000000a7400000, 0x00000000a7e00000)
+  to   space 10240K,   0% used [0x00000000a7e00000, 0x00000000a7e00000, 0x00000000a8800000)
+ concurrent mark-sweep generation total 204800K, used 0K [0x00000000c1800000, 0x00000000ce000000, 0x0000000100000000)
+ Metaspace       used 16922K, capacity 17202K, committed 17408K, reserved 1064960K
+  class space    used 2119K, capacity 2186K, committed 2304K, reserved 1048576K
+Event: 1,434 GC heap after
+Heap after GC invocations=1 (full 0):
+ par new generation   total 92160K, used 8410K [0x00000000a2400000, 0x00000000a8800000, 0x00000000c1800000)
+  eden space 81920K,   0% used [0x00000000a2400000, 0x00000000a2400000, 0x00000000a7400000)
+  from space 10240K,  82% used [0x00000000a7e00000, 0x00000000a8636a80, 0x00000000a8800000)
+  to   space 10240K,   0% used [0x00000000a7400000, 0x00000000a7400000, 0x00000000a7e00000)
+ concurrent mark-sweep generation total 204800K, used 0K [0x00000000c1800000, 0x00000000ce000000, 0x0000000100000000)
+ Metaspace       used 16922K, capacity 17202K, committed 17408K, reserved 1064960K
+  class space    used 2119K, capacity 2186K, committed 2304K, reserved 1048576K
+}
+Event: 2,167 GC heap before
+{Heap before GC invocations=1 (full 0):
+ par new generation   total 92160K, used 90330K [0x00000000a2400000, 0x00000000a8800000, 0x00000000c1800000)
+  eden space 81920K, 100% used [0x00000000a2400000, 0x00000000a7400000, 0x00000000a7400000)
+  from space 10240K,  82% used [0x00000000a7e00000, 0x00000000a8636a80, 0x00000000a8800000)
+  to   space 10240K,   0% used [0x00000000a7400000, 0x00000000a7400000, 0x00000000a7e00000)
+ concurrent mark-sweep generation total 204800K, used 0K [0x00000000c1800000, 0x00000000ce000000, 0x0000000100000000)
+ Metaspace       used 27075K, capacity 27312K, committed 27580K, reserved 1073152K
+  class space    used 2999K, capacity 3075K, committed 3148K, reserved 1048576K
+Event: 2,187 GC heap after
+Heap after GC invocations=2 (full 0):
+ par new generation   total 92160K, used 7947K [0x00000000a2400000, 0x00000000a8800000, 0x00000000c1800000)
+  eden space 81920K,   0% used [0x00000000a2400000, 0x00000000a2400000, 0x00000000a7400000)
+  from space 10240K,  77% used [0x00000000a7400000, 0x00000000a7bc2cd8, 0x00000000a7e00000)
+  to   space 10240K,   0% used [0x00000000a7e00000, 0x00000000a7e00000, 0x00000000a8800000)
+ concurrent mark-sweep generation total 204800K, used 3422K [0x00000000c1800000, 0x00000000ce000000, 0x0000000100000000)
+ Metaspace       used 27075K, capacity 27312K, committed 27580K, reserved 1073152K
+  class space    used 2999K, capacity 3075K, committed 3148K, reserved 1048576K
+}
+
+Deoptimization events (10 events):
+Event: 2,067 Thread 0x00007fb9d0c29000 Uncommon trap: reason=bimorphic action=maybe_recompile pc=0x00007fb9c16fe888 method=java.util.regex.Pattern$BmpCharProperty.match(Ljava/util/regex/Matcher;ILjava/lang/CharSequence;)Z @ 16
+Event: 2,225 Thread 0x00007fb9d0c29000 Uncommon trap: reason=class_check action=maybe_recompile pc=0x00007fb9c1750b40 method=java.util.regex.Pattern$Slice.match(Ljava/util/regex/Matcher;ILjava/lang/CharSequence;)Z @ 75
+Event: 2,240 Thread 0x00007fb9d0c29000 Uncommon trap: reason=unstable_if action=reinterpret pc=0x00007fb9c16f640c method=java.util.regex.Pattern$Branch.match(Ljava/util/regex/Matcher;ILjava/lang/CharSequence;)Z @ 9
+Event: 2,261 Thread 0x00007fb9d0c29000 Uncommon trap: reason=class_check action=maybe_recompile pc=0x00007fb9c1750b40 method=java.util.regex.Pattern$Slice.match(Ljava/util/regex/Matcher;ILjava/lang/CharSequence;)Z @ 75
+Event: 2,276 Thread 0x00007fb9d0c29000 Uncommon trap: reason=class_check action=maybe_recompile pc=0x00007fb9c1750b40 method=java.util.regex.Pattern$Slice.match(Ljava/util/regex/Matcher;ILjava/lang/CharSequence;)Z @ 75
+Event: 2,279 Thread 0x00007fb9d0c29000 Uncommon trap: reason=class_check action=maybe_recompile pc=0x00007fb9c1750b40 method=java.util.regex.Pattern$Slice.match(Ljava/util/regex/Matcher;ILjava/lang/CharSequence;)Z @ 75
+Event: 2,420 Thread 0x00007fb9d0c29000 Uncommon trap: reason=class_check action=maybe_recompile pc=0x00007fb9c1599044 method=java.lang.AbstractStringBuilder.append(Ljava/lang/CharSequence;II)Ljava/lang/AbstractStringBuilder; @ 18
+Event: 2,433 Thread 0x00007fb924869000 Uncommon trap: reason=unstable_if action=reinterpret pc=0x00007fb9c172a27c method=java.lang.ThreadLocal$ThreadLocalMap.getEntry(Ljava/lang/ThreadLocal;)Ljava/lang/ThreadLocal$ThreadLocalMap$Entry; @ 29
+Event: 5,555 Thread 0x00007fb92000a800 Uncommon trap: reason=unstable_if action=reinterpret pc=0x00007fb9c17a76d8 method=java.lang.ClassLoader.checkName(Ljava/lang/String;)Z @ 20
+Event: 5,555 Thread 0x00007fb92000a800 Uncommon trap: reason=unstable_if action=reinterpret pc=0x00007fb9c13da73c method=java.lang.ClassLoader.checkName(Ljava/lang/String;)Z @ 20
+
+Internal exceptions (10 events):
+Event: 1,385 Thread 0x00007fb9d000e000 Exception <a 'java/lang/NoSuchFieldError': method resolution failed> (0x00000000a7023c88) thrown at [/HUDSON/workspace/8-2-build-linux-amd64/jdk8u66/4988/hotspot/src/share/vm/prims/methodHandles.cpp, line 1146]
+Event: 1,387 Thread 0x00007fb9d000e000 Exception <a 'java/lang/NoSuchFieldError': method resolution failed> (0x00000000a7031b68) thrown at [/HUDSON/workspace/8-2-build-linux-amd64/jdk8u66/4988/hotspot/src/share/vm/prims/methodHandles.cpp, line 1146]
+Event: 1,666 Thread 0x00007fb9d000e000 Implicit null exception at 0x00007fb9c111daf6 to 0x00007fb9c111df79
+Event: 1,738 Thread 0x00007fb9d000e000 Exception <a 'java/lang/ClassNotFoundException': com/zaxxer/hikari/HikariConfigBeanInfo> (0x00000000a40524f8) thrown at [/HUDSON/workspace/8-2-build-linux-amd64/jdk8u66/4988/hotspot/src/share/vm/classfile/systemDictionary.cpp, line 210]
+Event: 1,738 Thread 0x00007fb9d000e000 Exception <a 'java/lang/ClassNotFoundException': com/zaxxer/hikari/AbstractHikariConfigBeanInfo> (0x00000000a406fb28) thrown at [/HUDSON/workspace/8-2-build-linux-amd64/jdk8u66/4988/hotspot/src/share/vm/classfile/systemDictionary.cpp, line 210]
+Event: 1,738 Thread 0x00007fb9d000e000 Exception <a 'java/lang/ClassNotFoundException': com/zaxxer/hikari/AbstractHikariConfigCustomizer> (0x00000000a408d8f0) thrown at [/HUDSON/workspace/8-2-build-linux-amd64/jdk8u66/4988/hotspot/src/share/vm/classfile/systemDictionary.cpp, line 210]
+Event: 1,742 Thread 0x00007fb9d000e000 Exception <a 'java/lang/ClassNotFoundException': com/zaxxer/hikari/HikariConfigCustomizer> (0x00000000a40fc7c8) thrown at [/HUDSON/workspace/8-2-build-linux-amd64/jdk8u66/4988/hotspot/src/share/vm/classfile/systemDictionary.cpp, line 210]
+Event: 1,758 Thread 0x00007fb9d0a75000 Implicit null exception at 0x00007fb9c13f65ab to 0x00007fb9c13f6d89
+Event: 1,843 Thread 0x00007fb9d0c29000 Exception <a 'java/lang/NullPointerException'> (0x00000000a5558a80) thrown at [/HUDSON/workspace/8-2-build-linux-amd64/jdk8u66/4988/hotspot/src/share/vm/interpreter/linkResolver.cpp, line 1178]
+Event: 1,955 Thread 0x00007fb9d0c29000 Implicit null exception at 0x00007fb9c12ab2d8 to 0x00007fb9c12ab366
+
+Events (10 events):
+Event: 10,934 Thread 0x00007fb92000a800 DEOPT PACKING pc=0x00007fb9c11e2e21 sp=0x00007fb97d781410
+Event: 10,934 Thread 0x00007fb92000a800 DEOPT UNPACKING pc=0x00007fb9c1047633 sp=0x00007fb97d781180 mode 1
+Event: 10,934 Thread 0x00007fb92000a800 DEOPT PACKING pc=0x00007fb9c18e1e9c sp=0x00007fb97d781490
+Event: 10,934 Thread 0x00007fb92000a800 DEOPT UNPACKING pc=0x00007fb9c1047633 sp=0x00007fb97d7812d0 mode 1
+Event: 10,934 Thread 0x00007fb92000a800 DEOPT PACKING pc=0x00007fb9c18e1c3c sp=0x00007fb97d781620
+Event: 10,934 Thread 0x00007fb92000a800 DEOPT UNPACKING pc=0x00007fb9c1047633 sp=0x00007fb97d781460 mode 1
+Event: 62,478 Thread 0x00007fb93000a000 Thread exited: 0x00007fb93000a000
+Event: 62,479 Thread 0x00007fb92486d000 Thread exited: 0x00007fb92486d000
+Event: 293,064 Executing VM operation: RedefineClasses
+Event: 293,092 Executing VM operation: RedefineClasses done
+
+
+Dynamic libraries:
+00400000-00401000 r-xp 00000000 fc:01 3415102                            /usr/lib/jvm/java-8-oracle/bin/java
+00600000-00601000 rw-p 00000000 fc:01 3415102                            /usr/lib/jvm/java-8-oracle/bin/java
+01710000-01731000 rw-p 00000000 00:00 0                                  [heap]
+a2400000-a8800000 rw-p 00000000 00:00 0 
+a8800000-c1800000 ---p 00000000 00:00 0 
+c1800000-ce000000 rw-p 00000000 00:00 0 
+ce000000-100000000 ---p 00000000 00:00 0 
+100000000-1003b3000 rw-p 00000000 00:00 0 
+1003b3000-140000000 ---p 00000000 00:00 0 
+7fb91c000000-7fb91c021000 rw-p 00000000 00:00 0 
+7fb91c021000-7fb920000000 ---p 00000000 00:00 0 
+7fb920000000-7fb920021000 rw-p 00000000 00:00 0 
+7fb920021000-7fb924000000 ---p 00000000 00:00 0 
+7fb924000000-7fb924c3e000 rw-p 00000000 00:00 0 
+7fb924c3e000-7fb928000000 ---p 00000000 00:00 0 
+7fb928000000-7fb928021000 rw-p 00000000 00:00 0 
+7fb928021000-7fb92c000000 ---p 00000000 00:00 0 
+7fb92c000000-7fb92c021000 rw-p 00000000 00:00 0 
+7fb92c021000-7fb930000000 ---p 00000000 00:00 0 
+7fb930000000-7fb930021000 rw-p 00000000 00:00 0 
+7fb930021000-7fb934000000 ---p 00000000 00:00 0 
+7fb934000000-7fb934021000 rw-p 00000000 00:00 0 
+7fb934021000-7fb938000000 ---p 00000000 00:00 0 
+7fb938000000-7fb93828b000 rw-p 00000000 00:00 0 
+7fb93828b000-7fb93c000000 ---p 00000000 00:00 0 
+7fb93c000000-7fb93c021000 rw-p 00000000 00:00 0 
+7fb93c021000-7fb940000000 ---p 00000000 00:00 0 
+7fb940000000-7fb940021000 rw-p 00000000 00:00 0 
+7fb940021000-7fb944000000 ---p 00000000 00:00 0 
+7fb944000000-7fb944021000 rw-p 00000000 00:00 0 
+7fb944021000-7fb948000000 ---p 00000000 00:00 0 
+7fb948000000-7fb948021000 rw-p 00000000 00:00 0 
+7fb948021000-7fb94c000000 ---p 00000000 00:00 0 
+7fb94c000000-7fb94c021000 rw-p 00000000 00:00 0 
+7fb94c021000-7fb950000000 ---p 00000000 00:00 0 
+7fb950000000-7fb950021000 rw-p 00000000 00:00 0 
+7fb950021000-7fb954000000 ---p 00000000 00:00 0 
+7fb954000000-7fb9547eb000 rw-p 00000000 00:00 0 
+7fb9547eb000-7fb958000000 ---p 00000000 00:00 0 
+7fb958000000-7fb958918000 rw-p 00000000 00:00 0 
+7fb958918000-7fb95c000000 ---p 00000000 00:00 0 
+7fb95c000000-7fb95ffe3000 rw-p 00000000 00:00 0 
+7fb95ffe3000-7fb960000000 ---p 00000000 00:00 0 
+7fb960000000-7fb961243000 rw-p 00000000 00:00 0 
+7fb961243000-7fb964000000 ---p 00000000 00:00 0 
+7fb964000000-7fb964021000 rw-p 00000000 00:00 0 
+7fb964021000-7fb968000000 ---p 00000000 00:00 0 
+7fb968000000-7fb968021000 rw-p 00000000 00:00 0 
+7fb968021000-7fb96c000000 ---p 00000000 00:00 0 
+7fb96c000000-7fb96c05d000 rw-p 00000000 00:00 0 
+7fb96c05d000-7fb970000000 ---p 00000000 00:00 0 
+7fb970000000-7fb970021000 rw-p 00000000 00:00 0 
+7fb970021000-7fb974000000 ---p 00000000 00:00 0 
+7fb974000000-7fb9742a5000 rw-p 00000000 00:00 0 
+7fb9742a5000-7fb978000000 ---p 00000000 00:00 0 
+7fb978000000-7fb978021000 rw-p 00000000 00:00 0 
+7fb978021000-7fb97c000000 ---p 00000000 00:00 0 
+7fb97c6e0000-7fb97c860000 rw-p 00000000 00:00 0 
+7fb97c860000-7fb97c8e0000 ---p 00000000 00:00 0 
+7fb97c8e0000-7fb97c8e3000 ---p 00000000 00:00 0 
+7fb97c8e3000-7fb97c9e1000 rw-p 00000000 00:00 0                          [stack:14198]
+7fb97c9e1000-7fb97c9e4000 ---p 00000000 00:00 0 
+7fb97c9e4000-7fb97cce2000 rw-p 00000000 00:00 0 
+7fb97cce2000-7fb97cee2000 rw-p 00000000 00:00 0 
+7fb97cee2000-7fb97d0e2000 rw-p 00000000 00:00 0 
+7fb97d0e2000-7fb97d0e5000 ---p 00000000 00:00 0 
+7fb97d0e5000-7fb97d1e3000 rw-p 00000000 00:00 0                          [stack:14192]
+7fb97d1e3000-7fb97d1eb000 r-xp 00000000 fc:01 3420262                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libmanagement.so
+7fb97d1eb000-7fb97d3eb000 ---p 00008000 fc:01 3420262                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libmanagement.so
+7fb97d3eb000-7fb97d3ec000 rw-p 00008000 fc:01 3420262                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libmanagement.so
+7fb97d483000-7fb97d684000 rw-p 00000000 00:00 0 
+7fb97d684000-7fb97d687000 ---p 00000000 00:00 0 
+7fb97d687000-7fb97d785000 rw-p 00000000 00:00 0                          [stack:14205]
+7fb97d785000-7fb97d788000 ---p 00000000 00:00 0 
+7fb97d788000-7fb97d886000 rw-p 00000000 00:00 0                          [stack:14191]
+7fb97d886000-7fb97d889000 ---p 00000000 00:00 0 
+7fb97d889000-7fb97d987000 rw-p 00000000 00:00 0 
+7fb97d987000-7fb97d98a000 ---p 00000000 00:00 0 
+7fb97d98a000-7fb97da88000 rw-p 00000000 00:00 0 
+7fb97da88000-7fb97da8b000 ---p 00000000 00:00 0 
+7fb97da8b000-7fb97db89000 rw-p 00000000 00:00 0                          [stack:14130]
+7fb97db89000-7fb97db8c000 ---p 00000000 00:00 0 
+7fb97db8c000-7fb97dc8a000 rw-p 00000000 00:00 0                          [stack:14138]
+7fb97dc8a000-7fb97dc8d000 ---p 00000000 00:00 0 
+7fb97dc8d000-7fb97dd8b000 rw-p 00000000 00:00 0                          [stack:14206]
+7fb97dd8b000-7fb97dd8e000 ---p 00000000 00:00 0 
+7fb97dd8e000-7fb97de8c000 rw-p 00000000 00:00 0                          [stack:14125]
+7fb97de8c000-7fb97de8f000 ---p 00000000 00:00 0 
+7fb97de8f000-7fb97e18d000 rw-p 00000000 00:00 0                          [stack:14122]
+7fb97e18d000-7fb97e19f000 r--s 00345000 fc:01 3420073                    /usr/lib/jvm/java-8-oracle/jre/lib/resources.jar
+7fb97e19f000-7fb97e39f000 rw-p 00000000 00:00 0 
+7fb97e39f000-7fb97e59f000 rw-p 00000000 00:00 0 
+7fb97e59f000-7fb97e79f000 rw-p 00000000 00:00 0 
+7fb97e79f000-7fb97e99f000 rw-p 00000000 00:00 0 
+7fb97e99f000-7fb97e9c5000 r--p 00000000 fc:01 3148863                    /usr/share/locale-langpack/es/LC_MESSAGES/libc.mo
+7fb97e9c5000-7fb97e9c6000 ---p 00000000 00:00 0 
+7fb97e9c6000-7fb97eac6000 rw-p 00000000 00:00 0                          [stack:14112]
+7fb97eac6000-7fb97eac9000 ---p 00000000 00:00 0 
+7fb97eac9000-7fb97ebc7000 rw-p 00000000 00:00 0                          [stack:14111]
+7fb97ebc7000-7fb97ebca000 ---p 00000000 00:00 0 
+7fb97ebca000-7fb97ecc8000 rw-p 00000000 00:00 0                          [stack:14110]
+7fb97ecc8000-7fb97eccb000 ---p 00000000 00:00 0 
+7fb97eccb000-7fb97edc9000 rw-p 00000000 00:00 0                          [stack:14109]
+7fb97edc9000-7fb97edcc000 ---p 00000000 00:00 0 
+7fb97edcc000-7fb97eeca000 rw-p 00000000 00:00 0                          [stack:14108]
+7fb97eeca000-7fb97eecd000 ---p 00000000 00:00 0 
+7fb97eecd000-7fb97efcb000 rw-p 00000000 00:00 0                          [stack:14107]
+7fb97efcb000-7fb97efce000 ---p 00000000 00:00 0 
+7fb97efce000-7fb97f0cc000 rw-p 00000000 00:00 0                          [stack:14106]
+7fb97f0cc000-7fb97f0dd000 r-xp 00000000 fc:01 3420257                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libnio.so
+7fb97f0dd000-7fb97f2dc000 ---p 00011000 fc:01 3420257                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libnio.so
+7fb97f2dc000-7fb97f2dd000 rw-p 00010000 fc:01 3420257                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libnio.so
+7fb97f2dd000-7fb97f5de000 rw-p 00000000 00:00 0 
+7fb97f5de000-7fb97f5f4000 r-xp 00000000 fc:01 3420254                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libnet.so
+7fb97f5f4000-7fb97f7f4000 ---p 00016000 fc:01 3420254                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libnet.so
+7fb97f7f4000-7fb97f7f5000 rw-p 00016000 fc:01 3420254                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libnet.so
+7fb97f7f5000-7fb97f7f7000 r-xp 00000000 fc:01 3420238                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libbci.so
+7fb97f7f7000-7fb97f9f6000 ---p 00002000 fc:01 3420238                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libbci.so
+7fb97f9f6000-7fb97f9f7000 rw-p 00001000 fc:01 3420238                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libbci.so
+7fb97f9f7000-7fb97f9fa000 ---p 00000000 00:00 0 
+7fb97f9fa000-7fb97faf8000 rw-p 00000000 00:00 0                          [stack:14105]
+7fb97faf8000-7fb97fafd000 r-xp 00000000 fc:01 3420246                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libjfr.so
+7fb97fafd000-7fb97fcfc000 ---p 00005000 fc:01 3420246                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libjfr.so
+7fb97fcfc000-7fb97fcfd000 rw-p 00004000 fc:01 3420246                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libjfr.so
+7fb97fcfd000-7fb97fd00000 ---p 00000000 00:00 0 
+7fb97fd00000-7fb97fdfe000 rw-p 00000000 00:00 0                          [stack:14103]
+7fb97fdfe000-7fb97fe01000 ---p 00000000 00:00 0 
+7fb97fe01000-7fb97feff000 rw-p 00000000 00:00 0                          [stack:14102]
+7fb97feff000-7fb97ff02000 ---p 00000000 00:00 0 
+7fb97ff02000-7fb980000000 rw-p 00000000 00:00 0                          [stack:14099]
+7fb980000000-7fb980021000 rw-p 00000000 00:00 0 
+7fb980021000-7fb984000000 ---p 00000000 00:00 0 
+7fb984000000-7fb984021000 rw-p 00000000 00:00 0 
+7fb984021000-7fb988000000 ---p 00000000 00:00 0 
+7fb988000000-7fb988021000 rw-p 00000000 00:00 0 
+7fb988021000-7fb98c000000 ---p 00000000 00:00 0 
+7fb98c000000-7fb98c021000 rw-p 00000000 00:00 0 
+7fb98c021000-7fb990000000 ---p 00000000 00:00 0 
+7fb990000000-7fb990021000 rw-p 00000000 00:00 0 
+7fb990021000-7fb994000000 ---p 00000000 00:00 0 
+7fb994000000-7fb994021000 rw-p 00000000 00:00 0 
+7fb994021000-7fb998000000 ---p 00000000 00:00 0 
+7fb998000000-7fb998021000 rw-p 00000000 00:00 0 
+7fb998021000-7fb99c000000 ---p 00000000 00:00 0 
+7fb99c000000-7fb99c021000 rw-p 00000000 00:00 0 
+7fb99c021000-7fb9a0000000 ---p 00000000 00:00 0 
+7fb9a0000000-7fb9a0002000 rw-p 00000000 00:00 0 
+7fb9a0002000-7fb9a0007000 r--s 00096000 fc:01 3420087                    /usr/lib/jvm/java-8-oracle/jre/lib/jsse.jar
+7fb9a0007000-7fb9a000e000 r--s 00000000 fc:01 3157743                    /usr/lib/x86_64-linux-gnu/gconv/gconv-modules.cache
+7fb9a000e000-7fb9a000f000 r--s 00000000 fc:01 4851782                    /home/gortiz/.m2/repository/javax/inject/javax.inject/1/javax.inject-1.jar
+7fb9a000f000-7fb9a0015000 r--s 00048000 fc:01 3945288                    /home/gortiz/.m2/repository/org/mongodb/mongodb-driver/3.0.4/mongodb-driver-3.0.4.jar
+7fb9a0015000-7fb9a0016000 r--s 00002000 fc:01 2233603                    /home/gortiz/.m2/repository/com/8kdata/mongowp/client/driver-wrapper/0.20-SNAPSHOT/driver-wrapper-0.20-SNAPSHOT.jar
+7fb9a0016000-7fb9a0018000 r--s 00000000 fc:01 2233595                    /home/gortiz/.m2/repository/com/8kdata/mongowp/client/core/0.20-SNAPSHOT/core-0.20-SNAPSHOT.jar
+7fb9a0018000-7fb9a001a000 r--s 0000d000 fc:01 1576043                    /home/gortiz/.m2/repository/commons-logging/commons-logging/1.1.1/commons-logging-1.1.1.jar
+7fb9a001a000-7fb9a001f000 r--s 00041000 fc:01 1575494                    /home/gortiz/.m2/repository/commons-lang/commons-lang/2.6/commons-lang-2.6.jar
+7fb9a001f000-7fb9a0026000 r--s 00052000 fc:01 4852161                    /home/gortiz/.m2/repository/commons-configuration/commons-configuration/1.10/commons-configuration-1.10.jar
+7fb9a0026000-7fb9a003e000 r--s 00121000 fc:01 4851975                    /home/gortiz/.m2/repository/org/mongodb/mongo-java-driver/3.0.1/mongo-java-driver-3.0.1.jar
+7fb9a003e000-7fb9a0045000 r--s 0009a000 fc:01 4852551                    /home/gortiz/.m2/repository/org/postgresql/postgresql/9.4-1206-jdbc41/postgresql-9.4-1206-jdbc41.jar
+7fb9a0045000-7fb9a004f000 r--s 000a5000 fc:01 4854067                    /home/gortiz/.m2/repository/org/javassist/javassist/3.18.2-GA/javassist-3.18.2-GA.jar
+7fb9a004f000-7fb9a0052000 r--s 00016000 fc:01 4853595                    /home/gortiz/.m2/repository/com/zaxxer/HikariCP-java6/2.3.8/HikariCP-java6-2.3.8.jar
+7fb9a0052000-7fb9a0054000 r--s 00001000 fc:01 1974741                    /home/gortiz/.m2/repository/com/torodb/torod/backend/0.40-SNAPSHOT/backend-0.40-SNAPSHOT.jar
+7fb9a0054000-7fb9a0055000 r--s 00004000 fc:01 4851940                    /home/gortiz/.m2/repository/javax/json/javax.json-api/1.0/javax.json-api-1.0.jar
+7fb9a0055000-7fb9a005c000 r--s 0005f000 fc:01 4852581                    /home/gortiz/.m2/repository/org/jooq/jooq-meta/3.6.4/jooq-meta-3.6.4.jar
+7fb9a005c000-7fb9a0073000 r--s 00167000 fc:01 4852580                    /home/gortiz/.m2/repository/org/jooq/jooq/3.6.4/jooq-3.6.4.jar
+7fb9a0073000-7fb9a0079000 r--s 00076000 fc:01 4851793                    /home/gortiz/.m2/repository/org/threeten/threetenbp/1.3/threetenbp-1.3.jar
+7fb9a0079000-7fb9a007d000 r--s 00020000 fc:01 4463971                    /home/gortiz/.m2/repository/io/netty/netty-codec/4.0.33.Final/netty-codec-4.0.33.Final.jar
+7fb9a007d000-7fb9a008d000 r--s 000a7000 fc:01 3945282                    /home/gortiz/.m2/repository/org/mongodb/mongodb-driver-core/3.0.4/mongodb-driver-core-3.0.4.jar
+7fb9a008d000-7fb9a0091000 r--s 0002d000 fc:01 4599091                    /home/gortiz/.m2/repository/io/netty/netty-buffer/4.0.33.Final/netty-buffer-4.0.33.Final.jar
+7fb9a0091000-7fb9a0099000 r--s 0004e000 fc:01 4463972                    /home/gortiz/.m2/repository/io/netty/netty-transport/4.0.33.Final/netty-transport-4.0.33.Final.jar
+7fb9a0099000-7fb9a00c4000 r--s 001fc000 fc:01 4851729                    /home/gortiz/.m2/repository/com/google/guava/guava/18.0/guava-18.0.jar
+7fb9a00c4000-7fb9a00c8000 r-xp 00000000 fc:01 3420220                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libdt_socket.so
+7fb9a00c8000-7fb9a02c7000 ---p 00004000 fc:01 3420220                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libdt_socket.so
+7fb9a02c7000-7fb9a02c8000 rw-p 00003000 fc:01 3420220                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libdt_socket.so
+7fb9a02c8000-7fb9a02cb000 ---p 00000000 00:00 0 
+7fb9a02cb000-7fb9a03c9000 rw-p 00000000 00:00 0                          [stack:14098]
+7fb9a03c9000-7fb9a03cc000 ---p 00000000 00:00 0 
+7fb9a03cc000-7fb9a0f08000 rw-p 00000000 00:00 0                          [stack:14097]
+7fb9a0f08000-7fb9a0f0b000 ---p 00000000 00:00 0 
+7fb9a0f0b000-7fb9a1009000 rw-p 00000000 00:00 0                          [stack:14096]
+7fb9a1009000-7fb9a100c000 ---p 00000000 00:00 0 
+7fb9a100c000-7fb9a110a000 rw-p 00000000 00:00 0                          [stack:14095]
+7fb9a110a000-7fb9a110b000 ---p 00000000 00:00 0 
+7fb9a110b000-7fb9a125a000 rw-p 00000000 00:00 0                          [stack:14094]
+7fb9a125a000-7fb9a1433000 r--s 03d20000 fc:01 3420037                    /usr/lib/jvm/java-8-oracle/jre/lib/rt.jar
+7fb9a1433000-7fb9a1d04000 rw-p 00000000 00:00 0 
+7fb9a1d04000-7fb9a1dfe000 rw-p 00000000 00:00 0 
+7fb9a1dfe000-7fb9a1dff000 ---p 00000000 00:00 0 
+7fb9a1dff000-7fb9a4000000 rw-p 00000000 00:00 0                          [stack:14093]
+7fb9a4000000-7fb9a4021000 rw-p 00000000 00:00 0 
+7fb9a4021000-7fb9a8000000 ---p 00000000 00:00 0 
+7fb9a8000000-7fb9a8021000 rw-p 00000000 00:00 0 
+7fb9a8021000-7fb9ac000000 ---p 00000000 00:00 0 
+7fb9ac000000-7fb9ac021000 rw-p 00000000 00:00 0 
+7fb9ac021000-7fb9b0000000 ---p 00000000 00:00 0 
+7fb9b0000000-7fb9b0021000 rw-p 00000000 00:00 0 
+7fb9b0021000-7fb9b4000000 ---p 00000000 00:00 0 
+7fb9b4000000-7fb9b4021000 rw-p 00000000 00:00 0 
+7fb9b4021000-7fb9b8000000 ---p 00000000 00:00 0 
+7fb9b8000000-7fb9b8021000 rw-p 00000000 00:00 0 
+7fb9b8021000-7fb9bc000000 ---p 00000000 00:00 0 
+7fb9bc000000-7fb9bc021000 rw-p 00000000 00:00 0 
+7fb9bc021000-7fb9c0000000 ---p 00000000 00:00 0 
+7fb9c0000000-7fb9c0005000 r--s 00032000 fc:01 3945276                    /home/gortiz/.m2/repository/org/mongodb/bson/3.0.4/bson-3.0.4.jar
+7fb9c0005000-7fb9c1000000 rw-p 00000000 00:00 0 
+7fb9c1000000-7fb9c1920000 rwxp 00000000 00:00 0 
+7fb9c1920000-7fb9d0000000 ---p 00000000 00:00 0 
+7fb9d0000000-7fb9d0c2a000 rw-p 00000000 00:00 0 
+7fb9d0c2a000-7fb9d4000000 ---p 00000000 00:00 0 
+7fb9d4000000-7fb9d4003000 r--s 00011000 fc:01 2233543                    /home/gortiz/.m2/repository/com/8kdata/mongowp/mongo-server-api-safe/0.20-SNAPSHOT/mongo-server-api-safe-0.20-SNAPSHOT.jar
+7fb9d4003000-7fb9d47a0000 rw-p 00000000 00:00 0 
+7fb9d47a0000-7fb9d47a1000 ---p 00000000 00:00 0 
+7fb9d47a1000-7fb9d48a1000 rw-p 00000000 00:00 0                          [stack:14092]
+7fb9d48a1000-7fb9d48a2000 ---p 00000000 00:00 0 
+7fb9d48a2000-7fb9d4a07000 rw-p 00000000 00:00 0                          [stack:14091]
+7fb9d4a07000-7fb9d4b97000 ---p 00000000 00:00 0 
+7fb9d4b97000-7fb9d53d1000 rw-p 00000000 00:00 0 
+7fb9d53d1000-7fb9d5499000 ---p 00000000 00:00 0 
+7fb9d5499000-7fb9d54fd000 rw-p 00000000 00:00 0 
+7fb9d54fd000-7fb9d568d000 ---p 00000000 00:00 0 
+7fb9d568d000-7fb9d568e000 rw-p 00000000 00:00 0 
+7fb9d568e000-7fb9d568f000 ---p 00000000 00:00 0 
+7fb9d568f000-7fb9d578f000 rw-p 00000000 00:00 0                          [stack:14090]
+7fb9d578f000-7fb9d5790000 ---p 00000000 00:00 0 
+7fb9d5790000-7fb9d5890000 rw-p 00000000 00:00 0                          [stack:14089]
+7fb9d5890000-7fb9d5891000 ---p 00000000 00:00 0 
+7fb9d5891000-7fb9d5991000 rw-p 00000000 00:00 0                          [stack:14088]
+7fb9d5991000-7fb9d5992000 ---p 00000000 00:00 0 
+7fb9d5992000-7fb9d5a92000 rw-p 00000000 00:00 0                          [stack:14087]
+7fb9d5a92000-7fb9d5a93000 ---p 00000000 00:00 0 
+7fb9d5a93000-7fb9d5b93000 rw-p 00000000 00:00 0                          [stack:14086]
+7fb9d5b93000-7fb9d5b94000 ---p 00000000 00:00 0 
+7fb9d5b94000-7fb9d5c94000 rw-p 00000000 00:00 0                          [stack:14085]
+7fb9d5c94000-7fb9d5c95000 ---p 00000000 00:00 0 
+7fb9d5c95000-7fb9d5d95000 rw-p 00000000 00:00 0                          [stack:14084]
+7fb9d5d95000-7fb9d5d96000 ---p 00000000 00:00 0 
+7fb9d5d96000-7fb9d5ebb000 rw-p 00000000 00:00 0                          [stack:14083]
+7fb9d5ebb000-7fb9d6256000 ---p 00000000 00:00 0 
+7fb9d6256000-7fb9d6270000 r-xp 00000000 fc:01 3420250                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libzip.so
+7fb9d6270000-7fb9d6470000 ---p 0001a000 fc:01 3420250                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libzip.so
+7fb9d6470000-7fb9d6471000 rw-p 0001a000 fc:01 3420250                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libzip.so
+7fb9d6471000-7fb9d647d000 r-xp 00000000 fc:01 262353                     /lib/x86_64-linux-gnu/libnss_files-2.21.so
+7fb9d647d000-7fb9d667c000 ---p 0000c000 fc:01 262353                     /lib/x86_64-linux-gnu/libnss_files-2.21.so
+7fb9d667c000-7fb9d667d000 r--p 0000b000 fc:01 262353                     /lib/x86_64-linux-gnu/libnss_files-2.21.so
+7fb9d667d000-7fb9d667e000 rw-p 0000c000 fc:01 262353                     /lib/x86_64-linux-gnu/libnss_files-2.21.so
+7fb9d667e000-7fb9d6689000 r-xp 00000000 fc:01 262198                     /lib/x86_64-linux-gnu/libnss_nis-2.21.so
+7fb9d6689000-7fb9d6888000 ---p 0000b000 fc:01 262198                     /lib/x86_64-linux-gnu/libnss_nis-2.21.so
+7fb9d6888000-7fb9d6889000 r--p 0000a000 fc:01 262198                     /lib/x86_64-linux-gnu/libnss_nis-2.21.so
+7fb9d6889000-7fb9d688a000 rw-p 0000b000 fc:01 262198                     /lib/x86_64-linux-gnu/libnss_nis-2.21.so
+7fb9d688a000-7fb9d68a1000 r-xp 00000000 fc:01 262362                     /lib/x86_64-linux-gnu/libnsl-2.21.so
+7fb9d68a1000-7fb9d6aa0000 ---p 00017000 fc:01 262362                     /lib/x86_64-linux-gnu/libnsl-2.21.so
+7fb9d6aa0000-7fb9d6aa1000 r--p 00016000 fc:01 262362                     /lib/x86_64-linux-gnu/libnsl-2.21.so
+7fb9d6aa1000-7fb9d6aa2000 rw-p 00017000 fc:01 262362                     /lib/x86_64-linux-gnu/libnsl-2.21.so
+7fb9d6aa2000-7fb9d6aa4000 rw-p 00000000 00:00 0 
+7fb9d6aa4000-7fb9d6aac000 r-xp 00000000 fc:01 262358                     /lib/x86_64-linux-gnu/libnss_compat-2.21.so
+7fb9d6aac000-7fb9d6cab000 ---p 00008000 fc:01 262358                     /lib/x86_64-linux-gnu/libnss_compat-2.21.so
+7fb9d6cab000-7fb9d6cac000 r--p 00007000 fc:01 262358                     /lib/x86_64-linux-gnu/libnss_compat-2.21.so
+7fb9d6cac000-7fb9d6cad000 rw-p 00008000 fc:01 262358                     /lib/x86_64-linux-gnu/libnss_compat-2.21.so
+7fb9d6cad000-7fb9d71ec000 r--p 00000000 fc:01 2884532                    /usr/lib/locale/locale-archive
+7fb9d71ec000-7fb9d71ee000 r-xp 00000000 fc:01 3420221                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libnpt.so
+7fb9d71ee000-7fb9d73ee000 ---p 00002000 fc:01 3420221                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libnpt.so
+7fb9d73ee000-7fb9d73ef000 rw-p 00002000 fc:01 3420221                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libnpt.so
+7fb9d73ef000-7fb9d7428000 r-xp 00000000 fc:01 3420239                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libjdwp.so
+7fb9d7428000-7fb9d7627000 ---p 00039000 fc:01 3420239                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libjdwp.so
+7fb9d7627000-7fb9d7629000 rw-p 00038000 fc:01 3420239                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libjdwp.so
+7fb9d7629000-7fb9d7653000 r-xp 00000000 fc:01 3420245                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libjava.so
+7fb9d7653000-7fb9d7853000 ---p 0002a000 fc:01 3420245                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libjava.so
+7fb9d7853000-7fb9d7855000 rw-p 0002a000 fc:01 3420245                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libjava.so
+7fb9d7855000-7fb9d7862000 r-xp 00000000 fc:01 3420249                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libverify.so
+7fb9d7862000-7fb9d7a62000 ---p 0000d000 fc:01 3420249                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libverify.so
+7fb9d7a62000-7fb9d7a64000 rw-p 0000d000 fc:01 3420249                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/libverify.so
+7fb9d7a64000-7fb9d7a6b000 r-xp 00000000 fc:01 262365                     /lib/x86_64-linux-gnu/librt-2.21.so
+7fb9d7a6b000-7fb9d7c6a000 ---p 00007000 fc:01 262365                     /lib/x86_64-linux-gnu/librt-2.21.so
+7fb9d7c6a000-7fb9d7c6b000 r--p 00006000 fc:01 262365                     /lib/x86_64-linux-gnu/librt-2.21.so
+7fb9d7c6b000-7fb9d7c6c000 rw-p 00007000 fc:01 262365                     /lib/x86_64-linux-gnu/librt-2.21.so
+7fb9d7c6c000-7fb9d7d73000 r-xp 00000000 fc:01 262361                     /lib/x86_64-linux-gnu/libm-2.21.so
+7fb9d7d73000-7fb9d7f72000 ---p 00107000 fc:01 262361                     /lib/x86_64-linux-gnu/libm-2.21.so
+7fb9d7f72000-7fb9d7f73000 r--p 00106000 fc:01 262361                     /lib/x86_64-linux-gnu/libm-2.21.so
+7fb9d7f73000-7fb9d7f74000 rw-p 00107000 fc:01 262361                     /lib/x86_64-linux-gnu/libm-2.21.so
+7fb9d7f74000-7fb9d8c32000 r-xp 00000000 fc:01 3420228                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/server/libjvm.so
+7fb9d8c32000-7fb9d8e31000 ---p 00cbe000 fc:01 3420228                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/server/libjvm.so
+7fb9d8e31000-7fb9d8f0a000 rw-p 00cbd000 fc:01 3420228                    /usr/lib/jvm/java-8-oracle/jre/lib/amd64/server/libjvm.so
+7fb9d8f0a000-7fb9d8f4e000 rw-p 00000000 00:00 0 
+7fb9d8f4e000-7fb9d910e000 r-xp 00000000 fc:01 262378                     /lib/x86_64-linux-gnu/libc-2.21.so
+7fb9d910e000-7fb9d930e000 ---p 001c0000 fc:01 262378                     /lib/x86_64-linux-gnu/libc-2.21.so
+7fb9d930e000-7fb9d9312000 r--p 001c0000 fc:01 262378                     /lib/x86_64-linux-gnu/libc-2.21.so
+7fb9d9312000-7fb9d9314000 rw-p 001c4000 fc:01 262378                     /lib/x86_64-linux-gnu/libc-2.21.so
+7fb9d9314000-7fb9d9318000 rw-p 00000000 00:00 0 
+7fb9d9318000-7fb9d931b000 r-xp 00000000 fc:01 262245                     /lib/x86_64-linux-gnu/libdl-2.21.so
+7fb9d931b000-7fb9d951a000 ---p 00003000 fc:01 262245                     /lib/x86_64-linux-gnu/libdl-2.21.so
+7fb9d951a000-7fb9d951b000 r--p 00002000 fc:01 262245                     /lib/x86_64-linux-gnu/libdl-2.21.so
+7fb9d951b000-7fb9d951c000 rw-p 00003000 fc:01 262245                     /lib/x86_64-linux-gnu/libdl-2.21.so
+7fb9d951c000-7fb9d9531000 r-xp 00000000 fc:01 3419841                    /usr/lib/jvm/java-8-oracle/lib/amd64/jli/libjli.so
+7fb9d9531000-7fb9d9731000 ---p 00015000 fc:01 3419841                    /usr/lib/jvm/java-8-oracle/lib/amd64/jli/libjli.so
+7fb9d9731000-7fb9d9732000 rw-p 00015000 fc:01 3419841                    /usr/lib/jvm/java-8-oracle/lib/amd64/jli/libjli.so
+7fb9d9732000-7fb9d974a000 r-xp 00000000 fc:01 262316                     /lib/x86_64-linux-gnu/libpthread-2.21.so
+7fb9d974a000-7fb9d994a000 ---p 00018000 fc:01 262316                     /lib/x86_64-linux-gnu/libpthread-2.21.so
+7fb9d994a000-7fb9d994b000 r--p 00018000 fc:01 262316                     /lib/x86_64-linux-gnu/libpthread-2.21.so
+7fb9d994b000-7fb9d994c000 rw-p 00019000 fc:01 262316                     /lib/x86_64-linux-gnu/libpthread-2.21.so
+7fb9d994c000-7fb9d9950000 rw-p 00000000 00:00 0 
+7fb9d9950000-7fb9d9974000 r-xp 00000000 fc:01 262253                     /lib/x86_64-linux-gnu/ld-2.21.so
+7fb9d9974000-7fb9d9976000 r--s 00009000 fc:01 2233513                    /home/gortiz/.m2/repository/com/8kdata/mongowp/mongo-server/0.20-SNAPSHOT/mongo-server-0.20-SNAPSHOT.jar
+7fb9d9976000-7fb9d997e000 r--s 00064000 fc:01 4599093                    /home/gortiz/.m2/repository/io/netty/netty-common/4.0.33.Final/netty-common-4.0.33.Final.jar
+7fb9d997e000-7fb9d9982000 r--s 00012000 fc:01 2233522                    /home/gortiz/.m2/repository/com/8kdata/mongowp/mongo-server-api/0.20-SNAPSHOT/mongo-server-api-0.20-SNAPSHOT.jar
+7fb9d9982000-7fb9d998d000 r--s 00065000 fc:01 1318633                    /home/gortiz/.m2/repository/ch/qos/logback/logback-core/1.1.3/logback-core-1.1.3.jar
+7fb9d998d000-7fb9d9993000 r--s 0003f000 fc:01 1318632                    /home/gortiz/.m2/repository/ch/qos/logback/logback-classic/1.1.3/logback-classic-1.1.3.jar
+7fb9d9993000-7fb9d9995000 r--s 0000d000 fc:01 4852160                    /home/gortiz/.m2/repository/com/beust/jcommander/1.47/jcommander-1.47.jar
+7fb9d9995000-7fb9d9a3f000 rw-p 00000000 00:00 0 
+7fb9d9a3f000-7fb9d9a42000 ---p 00000000 00:00 0 
+7fb9d9a42000-7fb9d9b44000 rw-p 00000000 00:00 0                          [stack:14078]
+7fb9d9b44000-7fb9d9b45000 r--s 00007000 fc:01 1318630                    /home/gortiz/.m2/repository/org/slf4j/slf4j-api/1.7.12/slf4j-api-1.7.12.jar
+7fb9d9b45000-7fb9d9b47000 r--s 00000000 fc:01 4851821                    /home/gortiz/.m2/repository/aopalliance/aopalliance/1.0/aopalliance-1.0.jar
+7fb9d9b47000-7fb9d9b55000 r--s 00096000 fc:01 4851583                    /home/gortiz/.m2/repository/com/google/inject/guice/4.0/guice-4.0.jar
+7fb9d9b55000-7fb9d9b58000 r--s 00012000 fc:01 4852067                    /home/gortiz/.m2/repository/org/glassfish/javax.json/1.0.4/javax.json-1.0.4.jar
+7fb9d9b58000-7fb9d9b62000 r--s 00116000 fc:01 3420099                    /usr/lib/jvm/java-8-oracle/jre/lib/ext/localedata.jar
+7fb9d9b62000-7fb9d9b67000 r--s 00083000 fc:01 3419947                    /usr/lib/jvm/java-8-oracle/jre/lib/jfr.jar
+7fb9d9b67000-7fb9d9b6f000 rw-s 00000000 fc:01 1180898                    /tmp/hsperfdata_gortiz/14077
+7fb9d9b6f000-7fb9d9b70000 rw-p 00000000 00:00 0 
+7fb9d9b70000-7fb9d9b71000 r--p 00000000 00:00 0 
+7fb9d9b71000-7fb9d9b73000 rw-p 00000000 00:00 0 
+7fb9d9b73000-7fb9d9b74000 r--p 00023000 fc:01 262253                     /lib/x86_64-linux-gnu/ld-2.21.so
+7fb9d9b74000-7fb9d9b75000 rw-p 00024000 fc:01 262253                     /lib/x86_64-linux-gnu/ld-2.21.so
+7fb9d9b75000-7fb9d9b76000 rw-p 00000000 00:00 0 
+7ffe79e3e000-7ffe79e60000 rw-p 00000000 00:00 0                          [stack]
+7ffe79fac000-7ffe79fae000 r--p 00000000 00:00 0                          [vvar]
+7ffe79fae000-7ffe79fb0000 r-xp 00000000 00:00 0                          [vdso]
+ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                  [vsyscall]
+
+VM Arguments:
+jvm_args: -Xdebug -Xrunjdwp:transport=dt_socket,server=n,address=39655 -Xmx1500m -Xms300m -XX:+UseConcMarkSweepGC -XX:+UnlockCommercialFeatures -XX:+FlightRecorder 
+java_command: com.torodb.Main -P 27018 -u torod -p 5433 --debug
+java_class_path (initial): /home/gortiz/proyectos/torodb/torodb/target/classes:/home/gortiz/.m2/repository/org/glassfish/javax.json/1.0.4/javax.json-1.0.4.jar:/home/gortiz/.m2/repository/com/google/inject/guice/4.0/guice-4.0.jar:/home/gortiz/.m2/repository/aopalliance/aopalliance/1.0/aopalliance-1.0.jar:/home/gortiz/.m2/repository/com/google/guava/guava/18.0/guava-18.0.jar:/home/gortiz/.m2/repository/com/beust/jcommander/1.47/jcommander-1.47.jar:/home/gortiz/.m2/repository/org/slf4j/slf4j-api/1.7.12/slf4j-api-1.7.12.jar:/home/gortiz/.m2/repository/ch/qos/logback/logback-classic/1.1.3/logback-classic-1.1.3.jar:/home/gortiz/.m2/repository/ch/qos/logback/logback-core/1.1.3/logback-core-1.1.3.jar:/home/gortiz/.m2/repository/com/8kdata/mongowp/mongo-server-api/0.20-SNAPSHOT/mongo-server-api-0.20-SNAPSHOT.jar:/home/gortiz/.m2/repository/io/netty/netty-common/4.0.33.Final/netty-common-4.0.33.Final.jar:/home/gortiz/proyectos/mongowp/mongowp-messages/target/classes:/home/gortiz/proyectos/mongowp/mongowp-protocol/target/classes:/home/gortiz/.m2/repository/org/mongodb/bson/3.0.4/bson-3.0.4.jar:/home/gortiz/.m2/repository/io/netty/netty-transport/4.0.33.Final/netty-transport-4.0.33.Final.jar:/home/gortiz/.m2/repository/io/netty/netty-buffer/4.0.33.Final/netty-buffer-4.0.33.Final.jar:/home/gortiz/.m2/repository/org/mongodb/mongodb-driver-core/3.0.4/mongodb-driver-core-3.0.4.jar:/home/gortiz/.m2/repository/com/8kdata/mongowp/mongo-server/0.20-SNAPSHOT/mongo-server-0.20-SNAPSHOT.jar:/home/gortiz/.m2/repository/io/netty/netty-codec/4.0.33.Final/netty-codec-4.0.33.Final.jar:/home/gortiz/.m2/repository/org/threeten/threetenbp/1.3/threetenbp-1.3.jar:/home/gortiz/.m2/repository/com/8kdata/mongowp/mongo-server-api-safe/0.20-SNAPSHOT/mongo-server-api-safe-0.20-SNAPSHOT.jar:/home/gortiz/proyectos/torodb/torod/connection/target/classes:/home/gortiz/proyectos/torodb/torod/d2r/target/classes:/home/gortiz/proyectos/torodb/kvdocument/core/target/classes:/home/gortiz/proyectos/torodb/torod/db
+Launcher Type: SUN_STANDARD
+
+Environment Variables:
+JAVA_HOME=/usr/lib/jvm/java-8-oracle
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
+LD_LIBRARY_PATH=/usr/lib/jvm/default-java/jre/lib/amd64:/usr/lib/jvm/default-java/jre/lib/i386:
+SHELL=/usr/bin/zsh
+DISPLAY=:0
+
+Signal Handlers:
+SIGSEGV: [libjvm.so+0xaba2a0], sa_mask[0]=11111111011111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
+SIGBUS: [libjvm.so+0xaba2a0], sa_mask[0]=11111111011111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
+SIGFPE: [libjvm.so+0x917710], sa_mask[0]=11111111011111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
+SIGPIPE: [libjvm.so+0x917710], sa_mask[0]=11111111011111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
+SIGXFSZ: [libjvm.so+0x917710], sa_mask[0]=11111111011111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
+SIGILL: [libjvm.so+0x917710], sa_mask[0]=11111111011111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
+SIGUSR1: SIG_DFL, sa_mask[0]=00000000000000000000000000000000, sa_flags=none
+SIGUSR2: [libjvm.so+0x918d40], sa_mask[0]=00100000000000000000000000000000, sa_flags=SA_RESTART|SA_SIGINFO
+SIGHUP: [libjvm.so+0x91a140], sa_mask[0]=11111111011111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
+SIGINT: SIG_IGN, sa_mask[0]=00000000000000000000000000000000, sa_flags=none
+SIGTERM: [libjvm.so+0x91a140], sa_mask[0]=11111111011111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
+SIGQUIT: [libjvm.so+0x91a140], sa_mask[0]=11111111011111111101111111111110, sa_flags=SA_RESTART|SA_SIGINFO
+
+
+---------------  S Y S T E M  ---------------
+
+OS:DISTRIB_ID=Ubuntu
+DISTRIB_RELEASE=15.10
+DISTRIB_CODENAME=wily
+DISTRIB_DESCRIPTION="Ubuntu 15.10"
+
+uname:Linux 4.2.0-19-generic #23-Ubuntu SMP Wed Nov 11 11:39:30 UTC 2015 x86_64
+libc:glibc 2.21 NPTL 2.21 
+rlimit: STACK 8192k, CORE 0k, NPROC 31471, NOFILE 65536, AS infinity
+load average:0,92 0,50 0,39
+
+/proc/meminfo:
+MemTotal:        8093544 kB
+MemFree:          830748 kB
+MemAvailable:    2944148 kB
+Buffers:          490768 kB
+Cached:          1924708 kB
+SwapCached:         1140 kB
+Active:          5089988 kB
+Inactive:        1831376 kB
+Active(anon):    3850712 kB
+Inactive(anon):  1059384 kB
+Active(file):    1239276 kB
+Inactive(file):   771992 kB
+Unevictable:          32 kB
+Mlocked:              32 kB
+SwapTotal:       8306684 kB
+SwapFree:        8287340 kB
+Dirty:              8636 kB
+Writeback:             0 kB
+AnonPages:       4504860 kB
+Mapped:           775828 kB
+Shmem:            404208 kB
+Slab:             200528 kB
+SReclaimable:     144480 kB
+SUnreclaim:        56048 kB
+KernelStack:       14960 kB
+PageTables:        65232 kB
+NFS_Unstable:          0 kB
+Bounce:                0 kB
+WritebackTmp:          0 kB
+CommitLimit:    12353456 kB
+Committed_AS:    9265836 kB
+VmallocTotal:   34359738367 kB
+VmallocUsed:      368172 kB
+VmallocChunk:   34358947836 kB
+HardwareCorrupted:     0 kB
+AnonHugePages:   2150400 kB
+CmaTotal:              0 kB
+CmaFree:               0 kB
+HugePages_Total:       0
+HugePages_Free:        0
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:       2048 kB
+DirectMap4k:      178516 kB
+DirectMap2M:     6031360 kB
+DirectMap1G:     3145728 kB
+
+
+CPU:total 8 (4 cores per cpu, 2 threads per core) family 6 model 70 stepping 1, cmov, cx8, fxsr, mmx, sse, sse2, sse3, ssse3, sse4.1, sse4.2, popcnt, avx, avx2, aes, clmul, erms, lzcnt, ht, tsc, tscinvbit, bmi1, bmi2
+
+/proc/cpuinfo:
+processor	: 0
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 70
+model name	: Intel(R) Core(TM) i7-4750HQ CPU @ 2.00GHz
+stepping	: 1
+microcode	: 0xa
+cpu MHz		: 3089.375
+cache size	: 6144 KB
+physical id	: 0
+siblings	: 8
+core id		: 0
+cpu cores	: 4
+apicid		: 0
+initial apicid	: 0
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf eagerfpu pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm ida arat epb pln pts dtherm tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt
+bugs		:
+bogomips	: 3990.74
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+processor	: 1
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 70
+model name	: Intel(R) Core(TM) i7-4750HQ CPU @ 2.00GHz
+stepping	: 1
+microcode	: 0xa
+cpu MHz		: 3000.000
+cache size	: 6144 KB
+physical id	: 0
+siblings	: 8
+core id		: 1
+cpu cores	: 4
+apicid		: 2
+initial apicid	: 2
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf eagerfpu pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm ida arat epb pln pts dtherm tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt
+bugs		:
+bogomips	: 3990.74
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+processor	: 2
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 70
+model name	: Intel(R) Core(TM) i7-4750HQ CPU @ 2.00GHz
+stepping	: 1
+microcode	: 0xa
+cpu MHz		: 3034.218
+cache size	: 6144 KB
+physical id	: 0
+siblings	: 8
+core id		: 2
+cpu cores	: 4
+apicid		: 4
+initial apicid	: 4
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf eagerfpu pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm ida arat epb pln pts dtherm tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt
+bugs		:
+bogomips	: 3990.74
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+processor	: 3
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 70
+model name	: Intel(R) Core(TM) i7-4750HQ CPU @ 2.00GHz
+stepping	: 1
+microcode	: 0xa
+cpu MHz		: 2999.843
+cache size	: 6144 KB
+physical id	: 0
+siblings	: 8
+core id		: 3
+cpu cores	: 4
+apicid		: 6
+initial apicid	: 6
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf eagerfpu pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm ida arat epb pln pts dtherm tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt
+bugs		:
+bogomips	: 3990.74
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+processor	: 4
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 70
+model name	: Intel(R) Core(TM) i7-4750HQ CPU @ 2.00GHz
+stepping	: 1
+microcode	: 0xa
+cpu MHz		: 3046.718
+cache size	: 6144 KB
+physical id	: 0
+siblings	: 8
+core id		: 0
+cpu cores	: 4
+apicid		: 1
+initial apicid	: 1
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf eagerfpu pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm ida arat epb pln pts dtherm tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt
+bugs		:
+bogomips	: 3990.74
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+processor	: 5
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 70
+model name	: Intel(R) Core(TM) i7-4750HQ CPU @ 2.00GHz
+stepping	: 1
+microcode	: 0xa
+cpu MHz		: 3018.281
+cache size	: 6144 KB
+physical id	: 0
+siblings	: 8
+core id		: 1
+cpu cores	: 4
+apicid		: 3
+initial apicid	: 3
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf eagerfpu pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm ida arat epb pln pts dtherm tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt
+bugs		:
+bogomips	: 3990.74
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+processor	: 6
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 70
+model name	: Intel(R) Core(TM) i7-4750HQ CPU @ 2.00GHz
+stepping	: 1
+microcode	: 0xa
+cpu MHz		: 3092.578
+cache size	: 6144 KB
+physical id	: 0
+siblings	: 8
+core id		: 2
+cpu cores	: 4
+apicid		: 5
+initial apicid	: 5
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf eagerfpu pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm ida arat epb pln pts dtherm tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt
+bugs		:
+bogomips	: 3990.74
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+processor	: 7
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 70
+model name	: Intel(R) Core(TM) i7-4750HQ CPU @ 2.00GHz
+stepping	: 1
+microcode	: 0xa
+cpu MHz		: 3023.359
+cache size	: 6144 KB
+physical id	: 0
+siblings	: 8
+core id		: 3
+cpu cores	: 4
+apicid		: 7
+initial apicid	: 7
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 13
+wp		: yes
+flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc aperfmperf eagerfpu pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm ida arat epb pln pts dtherm tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid xsaveopt
+bugs		:
+bogomips	: 3990.74
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+
+
+Memory: 4k page, physical 8093544k(830748k free), swap 8306684k(8287340k free)
+
+vm_info: Java HotSpot(TM) 64-Bit Server VM (25.66-b17) for linux-amd64 JRE (1.8.0_66-b17), built on Oct  6 2015 17:28:34 by "java_re" with gcc 4.3.0 20080428 (Red Hat 4.3.0-8)
+
+time: Thu Dec 17 17:17:23 2015
+elapsed time: 293 seconds (0d 0h 4m 53s)
+


### PR DESCRIPTION
The following code belongs to the main commit of this PR

A new ToroDB dependient command has been added. It is called
_sql-select_ and can be used to... execute selects on the backend
database. We know this is a security hole and the command will change
in future to be able to only select data from ToroDB related tables.
Meanwhile, the transaction where the command is executed is forced to
be read only.

The syntax of the command is the following:
{"sql-select": \<collection name\>, query: \<standard sql query\>}

For example, executing the following on mongo console (using the 
correct db!) will return all content from torodb.collections table
(the table where ToroDB stores collection metadata)
db.test.runCommand({
    "sql-select": "test4", 
    "query": "select * from torodb.collections"
})

The output is a cursor that contains one document for each row returned
by the query. Right know, the cursor only contains one batch. That means
all data returned by the query will be stored on memory and returned on
a (potentially) big response. In future a real cursor will be returned,
so it could be consumed with getMore.

Right know the collection provided as "sql-select" input field is not
really important and it is only used on the cursor namespace. In future
it could (or could not) constraint the schema where the query must be
executed.