### PR TITLE
Fixed a bug that prevents cursor connexions to be closed

### DIFF
--- a/torod/backends/common/src/main/java/com/torodb/torod/db/backends/sql/AbstractDbWrapper.java
+++ b/torod/backends/common/src/main/java/com/torodb/torod/db/backends/sql/AbstractDbWrapper.java
@@ -277,7 +277,7 @@ public abstract class AbstractDbWrapper implements DbWrapper {
         @Override
         public void close() throws SQLException {
             connection.commit();
-            connection.rollback();
+            connection.close();
             openCursors.remove(cursorId);
         }
 


### PR DESCRIPTION
Commit 55ebc79f67d0ed2f18a008edb25d27c2bfe8fe91 introduces a bug that
prevents cursors connections to be closed and therefore the database
became unusable after some read requests were executed