### PR TITLE
Moved integration tests to a new profile called _integration_

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-script: mvn -Psafer -Passembler -B -e -T 1C verify
+script: mvn -Psafer -Pintegration -Passembler -B -e -T 1C verify
 jdk:
 - oraclejdk8
 - oraclejdk7
@@ -20,13 +20,6 @@ deploy:
   file:
   - torodb/target/dist/torodb.tar.bz2
   - torodb/target/dist/torodb.zip
-  on:
-    repo: torodb/torodb
-    tags: true
-    jdk: oraclejdk8
-- provider: script
-  script: mvn -B -e -T 1C -Pdeploy -DskipTests=true deploy --settings ~/settings.xml
-  skip_cleanup: true
   on:
     repo: torodb/torodb
     tags: true

--- a/pom.xml
+++ b/pom.xml
@@ -457,26 +457,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.19</version>
-                        <executions>
-                            <execution>
-                                <id>integration-tests</id>
-                                <phase>integration-test</phase>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
-                                <configuration>
-                                    <skip>false</skip>
-                                    <includes>
-                                        <include>%regex[.*integration.*]</include>
-                                    </includes>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -495,6 +475,33 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>integration</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.19</version>
+                        <executions>
+                            <execution>
+                                <id>integration-tests</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>false</skip>
+                                    <includes>
+                                        <include>%regex[.*integration.*]</include>
+                                    </includes>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
Integration tests have been moved from _safer_ profile to a specific
_integration_ profile. All commiters must compile their branches with
_safer_ profile before their pull requests, but it doesn't seem to be
very realistic to force all commiters to have their develop environment
ready to run our integration tests (at least meanwhile they require very
specific environment configurations to be run).

Travis has been modified to enable both _safer_ and _integration_ tests,
so all PR will run the integration tests before they will be accepted.