### PR TITLE
Fixed a bug related to indexes 

### DIFF
--- a/torod/backends/common/src/main/java/com/torodb/torod/db/backends/converters/json/ToroIndexToJsonConverter.java
+++ b/torod/backends/common/src/main/java/com/torodb/torod/db/backends/converters/json/ToroIndexToJsonConverter.java
@@ -90,9 +90,9 @@ public class ToroIndexToJsonConverter implements Converter<String, NamedToroInde
             
             if (!entry.getValue()) {
                 descBuilder.add(attPosition);
-                attPosition++;
                 hasDescending = true;
             }
+            attPosition++;
         }
         objectBuilder.add(ATTS_KEY, attsBuilder);
         if (hasDescending) {


### PR DESCRIPTION
There was a bug on the way indexes that index more than one attribute
were stored that corrupt the index metadata. Once ToroDB checked that
metadata (ie when it starts again) it found an incompatibility between
the stored metadata and the real index and it stopped.