### PR TITLE
Fixed a couple of bugs related to specific configs on integration tests

### DIFF
--- a/torodb/src/test/java/com/torodb/integration/mongo/v3m0/jstests/JstestsIT.java
+++ b/torodb/src/test/java/com/torodb/integration/mongo/v3m0/jstests/JstestsIT.java
@@ -31,6 +31,8 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Charsets;
 import com.torodb.config.model.Config;
@@ -42,6 +44,8 @@ public abstract class JstestsIT {
 	public final static ToroRunnerClassRule toroRunnerClassRule = new ToroRunnerClassRule();
 	@Rule
 	public final MongoJstestIgnoreRule jstestIgnoreRule = new MongoJstestIgnoreRule();
+    private static final Logger LOGGER
+            = LoggerFactory.getLogger(JstestsIT.class);
 
 	private final Jstest jstest;
 	private final String testResource;
@@ -77,8 +81,10 @@ public abstract class JstestsIT {
 				+ config.getProtocol().getMongo().getNet().getPort() + "/"
 				+ config.getBackend().asPostgres().getDatabase();
 		URL mongoMocksUrl = Jstest.class.getResource("mongo_mocks.js");
-		
-		Process mongoProcess = Runtime.getRuntime()
+
+        LOGGER.info("Testing {}", testResource);
+
+        Process mongoProcess = Runtime.getRuntime()
 				.exec(new String[] {
 					"mongo",
 					toroConnectionString, 


### PR DESCRIPTION
Some configuration options were ignored on the integration tests. For
example, the default database was drop and created, even if a different
database is provided on the config file.

At the same time, a new log sentence have been added. It informs wich
js test is being running, so it will be easy to which test is failing
just looking at the logs.