### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/common/src/main/java/com/torodb/common/util/HexUtils.java
+++ b/common/src/main/java/com/torodb/common/util/HexUtils.java
@@ -42,6 +42,9 @@ public class HexUtils {
         }
     }
 
+    private HexUtils() {
+    }
+
     public static String bytes2Hex(@Nonnull byte[] bytes) {
         checkNotNull(bytes, "bytes");
 

--- a/torod/backends/common/src/main/java/com/torodb/torod/db/backends/query/processors/InProcessor.java
+++ b/torod/backends/common/src/main/java/com/torodb/torod/db/backends/query/processors/InProcessor.java
@@ -41,6 +41,9 @@ import javax.annotation.Nullable;
  */
 public class InProcessor {
 
+    private InProcessor() {
+    }
+
     public static List<ProcessedQueryCriteria> process(
             InQueryCriteria criteria,
             QueryCriteriaVisitor<List<ProcessedQueryCriteria>, Void> visitor) {

--- a/torod/backends/common/src/main/java/com/torodb/torod/db/backends/sql/path/view/TableAnalyzer.java
+++ b/torod/backends/common/src/main/java/com/torodb/torod/db/backends/sql/path/view/TableAnalyzer.java
@@ -23,6 +23,9 @@ class TableAnalyzer {
     private static final Logger LOGGER
             = LoggerFactory.getLogger(TableAnalyzer.class);
 
+    private TableAnalyzer() {
+    }
+
     public static Table<AttributeReference, Integer, DocStructure> analyzeCollection(
             IndexStorage.CollectionSchema colSchema,
             boolean ignoreArrays

--- a/torod/backends/common/src/test/java/com/torodb/torod/db/backends/query/processors/ProcessorTestUtils.java
+++ b/torod/backends/common/src/test/java/com/torodb/torod/db/backends/query/processors/ProcessorTestUtils.java
@@ -34,6 +34,9 @@ import java.util.Set;
  */
 public class ProcessorTestUtils {
 
+    private ProcessorTestUtils() {
+    }
+
     public static void testQueryCriteriaDifference(Set<QueryCriteria> result, Set<QueryCriteria> expected) {
         Set<QueryCriteriaWrapper> difference;
 

--- a/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/translator/ArrayModificationsApplicator.java
+++ b/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/translator/ArrayModificationsApplicator.java
@@ -39,6 +39,9 @@ public class ArrayModificationsApplicator {
     private static final OrExistsCreator OR_EXISTS_CREATOR = new OrExistsCreator();
     private static final QueryCriteriaFactory QUERY_CRITERIA_FACTORY = new QueryCriteriaFactory();
 
+    private ArrayModificationsApplicator() {
+    }
+
     public static QueryCriteria translate(QueryCriteria queryCriteria) {
         QueryCriteria withArrayAlternative = queryCriteria.accept(ARRAY_REFERENCE_CREATOR, null);
 

--- a/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/utils/NamespaceUtil.java
+++ b/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/utils/NamespaceUtil.java
@@ -11,6 +11,9 @@ public class NamespaceUtil {
     public static final String JS_COLLECTION = "system.js";
     public static final String LIST_COLLECTIONS_GET_MORE_COLLECTION = "$cmd.listCollections";
 
+    private NamespaceUtil() {
+    }
+
     public static boolean isNamespacesMetaCollection(String collection) {
         return collection.equals(NAMESPACES_COLLECTION);
     }

--- a/torod/torod-core/src/main/java/com/torodb/torod/core/language/querycriteria/utils/EqualFactory.java
+++ b/torod/torod-core/src/main/java/com/torodb/torod/core/language/querycriteria/utils/EqualFactory.java
@@ -43,6 +43,9 @@ import java.util.LinkedList;
  */
 public class EqualFactory {
 
+    private EqualFactory() {
+    }
+
     public static QueryCriteria createEquality(AttributeReference attRef, KVValue<?> docValue) {
         EqualityQueryFinder eqf = new EqualityQueryFinder(attRef);
 

--- a/torod/torod-core/src/main/java/com/torodb/torod/core/language/utils/AttributeReferenceResolver.java
+++ b/torod/torod-core/src/main/java/com/torodb/torod/core/language/utils/AttributeReferenceResolver.java
@@ -47,6 +47,9 @@ public class AttributeReferenceResolver {
     private static final DocStructureResolver docStructureResolver
             = new DocStructureResolver();
 
+    private AttributeReferenceResolver() {
+    }
+
     /**
      * Returns the type associated to the given attribute reference in the given
      * structure element.

--- a/torodb/src/main/java/com/torodb/config/util/ConfigUtils.java
+++ b/torodb/src/main/java/com/torodb/config/util/ConfigUtils.java
@@ -84,7 +84,10 @@ import ch.qos.logback.classic.Logger;
 public class ConfigUtils {
 
     private static final Logger LOGGER = (Logger) LoggerFactory.getLogger(ConfigUtils.class);
-    
+
+	private ConfigUtils() {
+	}
+
 	public static Config readConfig(final CliConfig cliConfig) throws FileNotFoundException, JsonProcessingException,
 			IOException, JsonParseException, JsonMappingException, Exception {
 		ObjectMapper objectMapper = new ObjectMapper();

--- a/torodb/src/main/java/com/torodb/util/LogbackUtils.java
+++ b/torodb/src/main/java/com/torodb/util/LogbackUtils.java
@@ -42,6 +42,9 @@ import ch.qos.logback.core.joran.spi.JoranException;
 
 public class LogbackUtils {
 
+	private LogbackUtils() {
+	}
+
 	public static void appendToLogFile(String logFile) {
 		LoggerContext loggerContext = getLoggerContext();
 		Logger root = getRootLogger();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.