### PR TITLE
Fixed document identifier field name from $_id to _id

### DIFF
--- a/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/utils/DefaultIdUtils.java
+++ b/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/utils/DefaultIdUtils.java
@@ -9,7 +9,7 @@ import com.eightkdata.mongowp.bson.BsonValue;
  */
 public class DefaultIdUtils {
 
-    public static final String DEFAULT_ID_KEY = "$_id";
+    public static final String DEFAULT_ID_KEY = "_id";
 
     private DefaultIdUtils() {}
 

--- a/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/utils/OplogOperationApplier.java
+++ b/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/utils/OplogOperationApplier.java
@@ -147,7 +147,7 @@ public class OplogOperationApplier {
             //Inserts must be executed as upserts to be idempotent
             BsonDocument query;
             if (!DefaultIdUtils.containsDefaultId(docToInsert)) {
-                query = docToInsert;  //as we dont have $_id, we need the whole document to be sure selector is correct
+                query = docToInsert;  //as we dont have _id, we need the whole document to be sure selector is correct
             } else {
                 query = newDocument(
                         DefaultIdUtils.DEFAULT_ID_KEY,


### PR DESCRIPTION
In replication InsertOplogOperation is looking for $_id field in document instead of _id, then try to find the document querying by all fields 