### PR TITLE
[squid:S2786] Nested "enum"s should not be declared static

### DIFF
--- a/common/src/main/java/com/torodb/common/util/RetryHelper.java
+++ b/common/src/main/java/com/torodb/common/util/RetryHelper.java
@@ -75,7 +75,7 @@ public class RetryHelper {
 
     }
 
-    private static enum RetryAction {
+    private enum RetryAction {
         RETRY,
         RETURN;
     }

--- a/kvdocument/core/src/main/java/com/torodb/kvdocument/values/KVBinary.java
+++ b/kvdocument/core/src/main/java/com/torodb/kvdocument/values/KVBinary.java
@@ -124,7 +124,7 @@ public abstract class KVBinary extends KVValue<KVBinary> {
         return visitor.visit(this, arg);
     }
 
-    public static enum KVBinarySubtype {
+    public enum KVBinarySubtype {
         UNDEFINED,
         MONGO_GENERIC,
         MONGO_FUNCTION,

--- a/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/translator/BasicQueryTranslator.java
+++ b/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/translator/BasicQueryTranslator.java
@@ -849,14 +849,14 @@ public class BasicQueryTranslator {
 
     }
 
-    private static enum NodeType {
+    private enum NodeType {
         EQUALITY,
         SUB_EXP,
         AND_OR_NOR,
         INVALID
     }
 
-    private static enum QueryOperator {
+    private enum QueryOperator {
 
         EQ_KEY("$eq"),
         GT_KEY("$gt"),

--- a/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/translator/UpdateActionTranslator.java
+++ b/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/translator/UpdateActionTranslator.java
@@ -277,7 +277,7 @@ public class UpdateActionTranslator {
         }
     }
 
-    private static enum UpdateOperator {
+    private enum UpdateOperator {
 
         INCREMENT("$inc"),
         MOVE("$rename"),


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2786 - “Nested "enum"s should not be declared static”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2786

Please let me know if you have any questions.
Ayman Abdelghany.