### PR TITLE
[squid:S2293] The operator ("<>") should be used.

### DIFF
--- a/torod/backends/common/src/main/java/com/torodb/torod/db/backends/converters/jooq/ArrayToJooqConverter.java
+++ b/torod/backends/common/src/main/java/com/torodb/torod/db/backends/converters/jooq/ArrayToJooqConverter.java
@@ -16,7 +16,7 @@ public class ArrayToJooqConverter<UT extends ScalarValue<?>> implements Converte
 
     public static <UT extends ScalarValue<?>, V extends JsonValue> DataType<UT> fromScalarValue(final Class<UT> type, final ArrayConverter<V, UT> arrayConverter, String typeName) {
         Converter<String, UT> converter = new ArrayToJooqConverter<>(type, arrayConverter);
-        return new DefaultDataType<String>(null, String.class, typeName).asConvertedDataType(converter);
+        return new DefaultDataType<>(null, String.class, typeName).asConvertedDataType(converter);
     }
     
     private final Class<UT> type;

--- a/torod/backends/common/src/main/java/com/torodb/torod/db/backends/converters/jooq/InstantValueConverter.java
+++ b/torod/backends/common/src/main/java/com/torodb/torod/db/backends/converters/jooq/InstantValueConverter.java
@@ -36,7 +36,7 @@ import com.torodb.torod.core.subdocument.values.heap.InstantScalarInstant;
 public class InstantValueConverter implements SubdocValueConverter<Timestamp, ScalarInstant>{
     private static final long serialVersionUID = 1L;
 
-    private static final DataType<Timestamp> TIMESTAMPTZ = new DefaultDataType<Timestamp>(null, Timestamp.class, "timestamptz");
+    private static final DataType<Timestamp> TIMESTAMPTZ = new DefaultDataType<>(null, Timestamp.class, "timestamptz");
     
     public static final DataTypeForScalar<ScalarInstant> TYPE = DataTypeForScalar.from(TIMESTAMPTZ, new InstantValueConverter());
 

--- a/torod/backends/common/src/main/java/com/torodb/torod/db/backends/converters/jooq/JSONBBinding.java
+++ b/torod/backends/common/src/main/java/com/torodb/torod/db/backends/converters/jooq/JSONBBinding.java
@@ -28,16 +28,16 @@ public class JSONBBinding<T> implements Binding<String, T> {
     private static final long serialVersionUID = 1L;
 
     public static <UT extends ScalarValue<?>> DataTypeForScalar<UT> fromScalarValue(Class<UT> type, SubdocValueConverter<String, UT> converter) {
-        return DataTypeForScalar.from(new DefaultDataType<String>(null, String.class, "jsonb"), converter, new JSONBBinding<UT>(converter));
+        return DataTypeForScalar.from(new DefaultDataType<>(null, String.class, "jsonb"), converter, new JSONBBinding<>(converter));
     }
     
     public static <UT extends ScalarValue<?>, V extends JsonValue> DataType<UT> fromScalarValue(final Class<UT> type, final ArrayConverter<V, UT> arrayConverter) {
         Converter<String, UT> converter = new ArrayToJooqConverter<>(type, arrayConverter);
-        return new DefaultDataType<String>(null, String.class, "jsonb").asConvertedDataType(new JSONBBinding<UT>(converter));
+        return new DefaultDataType<>(null, String.class, "jsonb").asConvertedDataType(new JSONBBinding<>(converter));
     }
     
     public static <UT> DataType<UT> fromType(Class<UT> type, Converter<String, UT> converter) {
-        return new DefaultDataType<String>(null, String.class, "jsonb").asConvertedDataType(new JSONBBinding<UT>(converter));
+        return new DefaultDataType<>(null, String.class, "jsonb").asConvertedDataType(new JSONBBinding<>(converter));
     }
 
     private final Converter<String, T> converter;

--- a/torod/backends/common/src/main/java/com/torodb/torod/db/backends/tables/AbstractCollectionsTable.java
+++ b/torod/backends/common/src/main/java/com/torodb/torod/db/backends/tables/AbstractCollectionsTable.java
@@ -134,7 +134,7 @@ public abstract class AbstractCollectionsTable<Record extends AbstractCollection
 	protected AbstractCollectionsTable(String alias, Table<Record> aliased, Field<?>[] parameters) {
 		super(alias, TorodbSchema.TORODB, aliased, parameters, "");
 		
-		this.uniqueKeys = new UniqueKeys<Record>(this);
+		this.uniqueKeys = new UniqueKeys<>(this);
 	}
     
     public String getSQLCreationStatement(DatabaseInterface databaseInterface) {

--- a/torod/backends/postgresql/src/main/java/com/torodb/torod/db/backends/postgresql/converters/jooq/PostgreSQLValueToJooqConverterProvider.java
+++ b/torod/backends/postgresql/src/main/java/com/torodb/torod/db/backends/postgresql/converters/jooq/PostgreSQLValueToJooqConverterProvider.java
@@ -65,7 +65,7 @@ public class PostgreSQLValueToJooqConverterProvider implements ValueToJooqConver
     private static final EnumMap<ScalarType, SubdocValueConverter> converters;
 
     static {
-        converters = new EnumMap<ScalarType, SubdocValueConverter>(ScalarType.class);
+        converters = new EnumMap<>(ScalarType.class);
 
         converters.put(ScalarType.ARRAY, new ArrayValueConverter(PostgreSQLValueToArrayConverterProvider.getInstance()));
         converters.put(ScalarType.BOOLEAN, new BooleanValueConverter());

--- a/torod/backends/postgresql/src/main/java/com/torodb/torod/db/backends/postgresql/converters/jooq/PostgreSQLValueToJooqDataTypeProvider.java
+++ b/torod/backends/postgresql/src/main/java/com/torodb/torod/db/backends/postgresql/converters/jooq/PostgreSQLValueToJooqDataTypeProvider.java
@@ -62,7 +62,7 @@ public class PostgreSQLValueToJooqDataTypeProvider implements ValueToJooqDataTyp
     private static final EnumMap<ScalarType, DataTypeForScalar<?>> dataTypes;
 
     static {
-        dataTypes = new EnumMap<ScalarType, DataTypeForScalar<?>>(ScalarType.class);
+        dataTypes = new EnumMap<>(ScalarType.class);
 
         dataTypes.put(ScalarType.ARRAY, ArrayValueConverter.TYPE);
         dataTypes.put(ScalarType.BOOLEAN, BooleanValueConverter.TYPE);

--- a/torod/backends/postgresql/src/main/java/com/torodb/torod/db/backends/postgresql/meta/PostgreSQLIndexStorage.java
+++ b/torod/backends/postgresql/src/main/java/com/torodb/torod/db/backends/postgresql/meta/PostgreSQLIndexStorage.java
@@ -61,8 +61,8 @@ public class PostgreSQLIndexStorage extends AbstractIndexStorage {
 
         @Override
         protected TableField<Record2<String, NamedToroIndex>, NamedToroIndex> createIndexField(ToroIndexToJsonConverter indexToJsonConverter) {
-            return createField("index", new DefaultDataType<String>(null, String.class, "jsonb")
-                    .asConvertedDataType(new JSONBBinding<NamedToroIndex>(indexToJsonConverter)), this, "");
+            return createField("index", new DefaultDataType<>(null, String.class, "jsonb")
+                    .asConvertedDataType(new JSONBBinding<>(indexToJsonConverter)), this, "");
         }
     }
 }

--- a/torod/db-executor/src/main/java/com/torodb/torod/db/backends/executor/DefaultSystemExecutor.java
+++ b/torod/db-executor/src/main/java/com/torodb/torod/db/backends/executor/DefaultSystemExecutor.java
@@ -138,7 +138,7 @@ class DefaultSystemExecutor implements SystemExecutor {
 
     private <R> Future<R> submit(Job<R> job) {
         taskCounter.incrementAndGet();
-        return executorService.submit(new SystemRunnable<R>(job));
+        return executorService.submit(new SystemRunnable<>(job));
     }
     
     private class SystemRunnable<R> implements Callable<R> {

--- a/torod/db-meta-inf/src/test/java/com/torodb/torod/db/backends/metaInf/DbMetaInformation_CreateSubDocumentTypeTable_FinishJobAfterContinue_Test.java
+++ b/torod/db-meta-inf/src/test/java/com/torodb/torod/db/backends/metaInf/DbMetaInformation_CreateSubDocumentTypeTable_FinishJobAfterContinue_Test.java
@@ -66,7 +66,7 @@ public class DbMetaInformation_CreateSubDocumentTypeTable_FinishJobAfterContinue
 
     @Before
     public void setUp() throws ToroTaskExecutionException, ImplementationDbException {
-        sequencer = new Sequencer<MySteps>(MySteps.class);
+        sequencer = new Sequencer<>(MySteps.class);
         future = Mockito.mock(Future.class);
         Mockito.doReturn(false).when(future).isDone();
 

--- a/torod/db-meta-inf/src/test/java/com/torodb/torod/db/backends/metaInf/DbMetaInformation_CreateSubDocumentTypeTable_FinishJobBeforeContinue_Test.java
+++ b/torod/db-meta-inf/src/test/java/com/torodb/torod/db/backends/metaInf/DbMetaInformation_CreateSubDocumentTypeTable_FinishJobBeforeContinue_Test.java
@@ -66,7 +66,7 @@ public class DbMetaInformation_CreateSubDocumentTypeTable_FinishJobBeforeContinu
 
     @Before
     public void setUp() throws ToroTaskExecutionException, ImplementationDbException {
-        sequencer = new Sequencer<MySteps>(MySteps.class);
+        sequencer = new Sequencer<>(MySteps.class);
         future = mock(Future.class);
 
         type = new SimpleSubDocTypeBuilderProvider().get().add(new SubDocAttribute("att1", ScalarType.STRING)).build();

--- a/torod/db-meta-inf/src/test/java/com/torodb/torod/tools/sequencer/Sequencer.java
+++ b/torod/db-meta-inf/src/test/java/com/torodb/torod/tools/sequencer/Sequencer.java
@@ -37,7 +37,7 @@ public class Sequencer<E extends Enum<E>> {
 
     public Sequencer(Class<E> messagesEnum) {
         sentMessages = EnumSet.noneOf(messagesEnum);
-        reservedMessages = new EnumMap<E, java.lang.Thread>(messagesEnum);
+        reservedMessages = new EnumMap<>(messagesEnum);
     }
     
     public void waitFor(E message) {

--- a/torod/db-meta-inf/src/test/java/com/torodb/torod/tools/sequencer/SequencerTest.java
+++ b/torod/db-meta-inf/src/test/java/com/torodb/torod/tools/sequencer/SequencerTest.java
@@ -47,7 +47,7 @@ public class SequencerTest {
 
     public SequencerTest(long maxExpectedMillis) {
         this.maxExpectedMillis = maxExpectedMillis;
-        this.throwables = new ConcurrentLinkedQueue<Throwable>();
+        this.throwables = new ConcurrentLinkedQueue<>();
     }
 
     @Test
@@ -60,7 +60,7 @@ public class SequencerTest {
     }
 
     public static void test(Object testCase, long maxExpectedMillis, ConcurrentLinkedQueue<Throwable> throwables) throws SequencerTimeoutException, Throwable {
-        Collection<Thread> threads = new LinkedList<Thread>();
+        Collection<Thread> threads = new LinkedList<>();
         Class<?> c = testCase.getClass();
         for (Method method : c.getMethods()) {
             if (method.isAnnotationPresent(ConcurrentTest.class)) {
@@ -123,7 +123,7 @@ public class SequencerTest {
     }
 
     private static void joinThreads(Collection<Thread> threads, boolean previousError) throws SequencerTimeoutException {
-        Collection<Thread> blockedThreads = new LinkedList<Thread>();
+        Collection<Thread> blockedThreads = new LinkedList<>();
 
         for (Thread thread : threads) {
             if (thread.isAlive()) {

--- a/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/commands/AbstractToroRetryCommandImplementation.java
+++ b/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/commands/AbstractToroRetryCommandImplementation.java
@@ -31,9 +31,9 @@ public abstract class AbstractToroRetryCommandImplementation<Arg, Rep> extends A
     private static final Logger LOGGER
             = LoggerFactory.getLogger(AbstractToroRetryCommandImplementation.class);
 
-    private final RetryTransactionHandler<CommandResult<Rep>> retryTransactionHandler = 
-            new RetryTransactionHandler<CommandResult<Rep>>(
-                    RetryHelper.<CommandResult<Rep>, MongoException>retryUntilHandler(64, 
+    private final RetryTransactionHandler<CommandResult<Rep>> retryTransactionHandler =
+            new RetryTransactionHandler<>(
+                    RetryHelper.<CommandResult<Rep>, MongoException>retryUntilHandler(64,
                             RetryHelper.<CommandResult<Rep>, MongoException>throwHandler()));
     
     @Nonnull

--- a/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/commands/impl/admin/DropCollectionImplementation.java
+++ b/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/commands/impl/admin/DropCollectionImplementation.java
@@ -33,7 +33,7 @@ public class DropCollectionImplementation extends
         }
         connection.dropCollection(collection);
 
-        return new NonWriteCommandResult<Empty>(Empty.getInstance());
+        return new NonWriteCommandResult<>(Empty.getInstance());
 
     }
 

--- a/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/commands/impl/admin/DropDatabaseImplementation.java
+++ b/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/commands/impl/admin/DropDatabaseImplementation.java
@@ -43,7 +43,7 @@ public class DropDatabaseImplementation extends AbstractToroCommandImplementatio
 
         if (!supporteDatabase.equals(database)) {
             LOGGER.warn("Ignoring drop database command with database {}. Only {} is supported", database, supporteDatabase);
-            return new NonWriteCommandResult<Empty>(Empty.getInstance());
+            return new NonWriteCommandResult<>(Empty.getInstance());
         }
         else {
             try {

--- a/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/commands/impl/admin/ListCollectionsImplementation.java
+++ b/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/commands/impl/admin/ListCollectionsImplementation.java
@@ -96,7 +96,7 @@ public class ListCollectionsImplementation extends
                     )
             );
 
-            MongoCursor<ListCollectionsResult.Entry> resultCursor = new FirstBatchOnlyCursor<Entry>(
+            MongoCursor<ListCollectionsResult.Entry> resultCursor = new FirstBatchOnlyCursor<>(
                     0,
                     req.getDatabase(),
                     NamespaceUtil.LIST_COLLECTIONS_GET_MORE_COLLECTION,
@@ -105,7 +105,7 @@ public class ListCollectionsImplementation extends
             );
             ListCollectionsResult result = new ListCollectionsResult(resultCursor);
 
-            return new NonWriteCommandResult<ListCollectionsResult>(result);
+            return new NonWriteCommandResult<>(result);
         } catch (ClosedToroCursorException ex) {
             throw new CommandFailed(
                     command.getCommandName(),

--- a/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/commands/impl/diagnostic/CollStatsImplementation.java
+++ b/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/commands/impl/diagnostic/CollStatsImplementation.java
@@ -128,7 +128,7 @@ public class CollStatsImplementation extends AbstractToroCommandImplementation<C
             }
         }
         
-        return new NonWriteCommandResult<CollStatsReply>(replyBuilder.build());
+        return new NonWriteCommandResult<>(replyBuilder.build());
     }
 
 }

--- a/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/commands/impl/diagnostic/ListDatabasesImplementation.java
+++ b/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/commands/impl/diagnostic/ListDatabasesImplementation.java
@@ -51,7 +51,7 @@ public class ListDatabasesImplementation extends AbstractToroCommandImplementati
                     );
                     totalSize += database.getSize();
                 }
-                return new NonWriteCommandResult<ListDatabasesReply>(
+                return new NonWriteCommandResult<>(
                         new ListDatabasesReply(
                                 databaseEntries,
                                 totalSize

--- a/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/commands/impl/general/GetLastErrorImplementation.java
+++ b/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/commands/impl/general/GetLastErrorImplementation.java
@@ -35,7 +35,7 @@ public class GetLastErrorImplementation implements CommandImplementation<GetLast
     public CommandResult<GetLastErrorReply> apply(
             Command<? super GetLastErrorArgument, ? super GetLastErrorReply> command,
             CommandRequest<GetLastErrorArgument> req) throws MongoException {
-        return new NonWriteCommandResult<GetLastErrorReply>(getResult(command, req));
+        return new NonWriteCommandResult<>(getResult(command, req));
     }
 
     public GetLastErrorReply getResult(

--- a/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/crp/StandardCollectionRequestProcessor.java
+++ b/torod/mongodb-layer/src/main/java/com/torodb/torod/mongodb/crp/StandardCollectionRequestProcessor.java
@@ -324,7 +324,7 @@ public class StandardCollectionRequestProcessor implements CollectionRequestProc
     		}
     	}
     	QueryCriteria queryCriteria = queryCriteriaTranslator.translate(query);
-    	List<DeleteOperation> deletes = new ArrayList<DeleteOperation>();
+    	List<DeleteOperation> deletes = new ArrayList<>();
     	boolean singleRemove = deleteMessage.isSingleRemove();
 
     	deletes.add(new DeleteOperation(queryCriteria, singleRemove));

--- a/torod/torod-core/src/main/java/com/torodb/torod/core/language/utils/AttributeReferenceResolver.java
+++ b/torod/torod-core/src/main/java/com/torodb/torod/core/language/utils/AttributeReferenceResolver.java
@@ -370,8 +370,8 @@ public class AttributeReferenceResolver {
             public Argument(List<AttributeReference.Key> keys) {
                 this.keys = keys;
                 depth = 0;
-                docStructureStack = new LinkedList<DocStructure>();
-                docStructureDepthStack = new LinkedList<Integer>();
+                docStructureStack = new LinkedList<>();
+                docStructureDepthStack = new LinkedList<>();
             }
 
             public void addDocStructure(DocStructure structure) {

--- a/torod/torod-core/src/main/java/com/torodb/torod/core/subdocument/SplitDocument.java
+++ b/torod/torod-core/src/main/java/com/torodb/torod/core/subdocument/SplitDocument.java
@@ -204,7 +204,7 @@ public class SplitDocument {
         }
 
         private boolean checkCorrectness() {
-            Deque<DocStructure> structuresToCheck = new LinkedList<DocStructure>();
+            Deque<DocStructure> structuresToCheck = new LinkedList<>();
             structuresToCheck.add(root);
             while (!structuresToCheck.isEmpty()) {
                 DocStructure docStructure = structuresToCheck.removeLast();

--- a/torod/torod-core/src/main/java/com/torodb/torod/core/subdocument/SubDocType.java
+++ b/torod/torod-core/src/main/java/com/torodb/torod/core/subdocument/SubDocType.java
@@ -104,7 +104,7 @@ public class SubDocType implements Serializable {
 
     public static class Builder {
 
-        private final Map<String, SubDocAttribute> attributes = new HashMap<String, SubDocAttribute>();
+        private final Map<String, SubDocAttribute> attributes = new HashMap<>();
         private boolean built;
 
         Builder() {

--- a/torod/torod-core/src/main/java/com/torodb/torod/core/utils/TriValuedResult.java
+++ b/torod/torod-core/src/main/java/com/torodb/torod/core/utils/TriValuedResult.java
@@ -50,7 +50,7 @@ public class TriValuedResult<E> {
     }
 
     public static <E> TriValuedResult<E> createValue(E value) {
-        return new TriValuedResult<E>(value);
+        return new TriValuedResult<>(value);
     }
     
     public boolean isUndecidable() {

--- a/torodb/src/main/java/com/torodb/config/util/ConfigUtils.java
+++ b/torodb/src/main/java/com/torodb/config/util/ConfigUtils.java
@@ -268,8 +268,8 @@ public class ConfigUtils {
 		if (pathNode.isMissingNode() || pathNode.isNull()) {
 			JsonPointer currentPointer = pathPointer;
 			JsonPointer childOfCurrentPointer = null;
-			List<JsonPointer> missingPointers = new ArrayList<JsonPointer>();
-			List<JsonPointer> childOfMissingPointers = new ArrayList<JsonPointer>();
+			List<JsonPointer> missingPointers = new ArrayList<>();
+			List<JsonPointer> childOfMissingPointers = new ArrayList<>();
 			do {
 				if (pathNode.isMissingNode() || pathNode.isNull()) {
 					missingPointers.add(0, currentPointer);
@@ -285,7 +285,7 @@ public class ConfigUtils {
 				final JsonPointer missingPointer = missingPointers.get(missingPointerIndex);
 				final JsonPointer childOfMissingPointer = childOfMissingPointers.get(missingPointerIndex);
 
-				final List<JsonNode> newNodes = new ArrayList<JsonNode>();
+				final List<JsonNode> newNodes = new ArrayList<>();
 
 				if (pathNode.isObject()) {
 					((ObjectNode) pathNode).set(missingPointer.last().getMatchingProperty(),

--- a/torodb/src/main/java/com/torodb/config/validation/NoDuplicatedReplNameValidator.java
+++ b/torodb/src/main/java/com/torodb/config/validation/NoDuplicatedReplNameValidator.java
@@ -38,7 +38,7 @@ public class NoDuplicatedReplNameValidator implements ConstraintValidator<NoDupl
 	@Override
 	public boolean isValid(List<Replication> value, ConstraintValidatorContext context) {
 		if (value != null) {
-			Set<String> replNameSet = new HashSet<String>();
+			Set<String> replNameSet = new HashSet<>();
 			for (Replication replication : value) {
 				if (!replNameSet.add(replication.getReplSetName())) {
 					return false;

--- a/torodb/src/main/java/com/torodb/util/LogbackUtils.java
+++ b/torodb/src/main/java/com/torodb/util/LogbackUtils.java
@@ -62,7 +62,7 @@ public class LogbackUtils {
 		patternLayoutEncoder.setPattern(pattern);
 		patternLayoutEncoder.start();
 		
-		FileAppender<ILoggingEvent> fileAppender = new FileAppender<ILoggingEvent>();
+		FileAppender<ILoggingEvent> fileAppender = new FileAppender<>();
 		fileAppender.setFile(logFile);
 		fileAppender.setContext(loggerContext);
 		fileAppender.setEncoder(patternLayoutEncoder);

--- a/torodb/src/test/java/com/torodb/integration/ToroRunnerClassRule.java
+++ b/torodb/src/test/java/com/torodb/integration/ToroRunnerClassRule.java
@@ -91,7 +91,7 @@ public class ToroRunnerClassRule implements TestRule {
 		};
 	}
 	
-	private final Set<Throwable> UNCAUGHT_EXCEPTIONS = new HashSet<Throwable>();
+	private final Set<Throwable> UNCAUGHT_EXCEPTIONS = new HashSet<>();
 
 	private boolean started = false;
 	private Shutdowner shutdowner;
@@ -129,7 +129,7 @@ public class ToroRunnerClassRule implements TestRule {
 	public List<Throwable> getUcaughtExceptions() {
 		List<Throwable> ucaughtExceptions;
 		synchronized (UNCAUGHT_EXCEPTIONS) {
-			ucaughtExceptions = new ArrayList<Throwable>(UNCAUGHT_EXCEPTIONS);
+			ucaughtExceptions = new ArrayList<>(UNCAUGHT_EXCEPTIONS);
 			UNCAUGHT_EXCEPTIONS.clear();
 		}
 		return ucaughtExceptions;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2293 - “The diamond operator ("<>") should be used ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293

Please let me know if you have any questions.
Ayman Abdelghany.