### PR TITLE
[squid:MissingDeprecatedCheck] Deprecated elements should have both the annotation and the Javadoc tag

### DIFF
--- a/torodb/src/main/java/com/torodb/config/model/backend/postgres/Postgres.java
+++ b/torodb/src/main/java/com/torodb/config/model/backend/postgres/Postgres.java
@@ -56,6 +56,9 @@ public class Postgres implements BackendImplementation, Password {
 	@JsonProperty(required=true)
 	private Integer port = 5432;
 	@Description("config.backend.postgres.database")
+	/**
+	 * @deprecated kept for backward compatibility
+	 */
 	@Deprecated
 	@NotNull
 	@JsonProperty(required=true)
@@ -103,10 +106,20 @@ public class Postgres implements BackendImplementation, Password {
 	public void setToropassFile(String toropassFile) {
 		this.toropassFile = toropassFile;
 	}
+
+	/**
+	 * @deprecated kept for backward compatibility
+	 * @return
+     */
 	@Deprecated
 	public String getDatabase() {
 		return database;
 	}
+
+	/**
+	 * @deprecated kept for backward compatibility
+	 * @param database
+     */
 	@Deprecated
 	public void setDatabase(String database) {
 		this.database = database;

--- a/torodb/src/main/java/com/torodb/config/model/protocol/mongo/Replication.java
+++ b/torodb/src/main/java/com/torodb/config/model/protocol/mongo/Replication.java
@@ -43,6 +43,9 @@ public class Replication {
 	@JsonProperty(required=true)
 	private Role role = Role.HIDDEN_SLAVE;
 	@Description("config.protocol.mongo.replication.syncSource")
+	/**
+	 * @deprecated kept for backward compatibility
+	 */
 	@Deprecated
 	private String syncSource;
 	
@@ -58,10 +61,20 @@ public class Replication {
 	public void setRole(Role role) {
 		this.role = role;
 	}
+
+	/**
+	 * @deprecated kept for backward compatibility
+	 * @return
+     */
 	@Deprecated
 	public String getSyncSource() {
 		return syncSource;
 	}
+
+	/**
+	 * @deprecated kept for backward compatibility
+	 * @param syncSource
+     */
 	@Deprecated
 	public void setSyncSource(String syncSource) {
 		this.syncSource = syncSource;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:MissingDeprecatedCheck - “ Deprecated elements should have both the annotation and the Javadoc tag ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:MissingDeprecatedCheck

Please let me know if you have any questions.
Ayman Abdelghany.