### PR TITLE
Ignoring checkstyle autogenerated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ target/
 .project
 .classpath
 .settings/
+.checkstyle
 hs_err*.log
 /documentation/static
 /documentation/site

--- a/engine/mongodb/repl/src/main/java/com/torodb/mongodb/repl/commands/impl/CreateIndexesReplImpl.java
+++ b/engine/mongodb/repl/src/main/java/com/torodb/mongodb/repl/commands/impl/CreateIndexesReplImpl.java
@@ -144,8 +144,8 @@ public class CreateIndexesReplImpl
         }
 
         try {
-          LOGGER.info("Creating index {} on collection {}.{}", req.getDatabase(), arg
-              .getCollection(), indexOptions.getName());
+          LOGGER.info("Creating index {} on collection {}.{}", 
+              indexOptions.getName(), req.getDatabase(), arg.getCollection());
 
           if (trans.createIndex(req.getDatabase(), arg.getCollection(), indexOptions.getName(),
               fields, indexOptions.isUnique())) {


### PR DESCRIPTION
Tables under root table are created with internal indexes on (did) and on (did, seq). We remove (did) index since it is useless.