### PR TITLE
Fix ISO8601 compatible timestamp format on maven package

### DIFF
--- a/engine/packaging-utils/pom.xml
+++ b/engine/packaging-utils/pom.xml
@@ -12,7 +12,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssXX</maven.build.timestamp.format>
+        <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ss'Z'</maven.build.timestamp.format>
         <build.timestamp>${maven.build.timestamp}</build.timestamp>
     </properties>
     

--- a/licensing.txt
+++ b/licensing.txt
@@ -1,0 +1,51 @@
+Dependencies used on this code and their licenses:
+
+MongoWP                         AGPL3 or Commercial License
+Log4j                           Apache-2.0
+Guava                           Apache-2.0
+javax.json                      CDDL+GPLv2 with classpath exception
+mongodb-driver (by MongoDB)     Apache-2.0
+bson (by MongoDB)               Apache-2.0
+javax.inject                    Apache-2.0
+commons-configuration           Apache-2.0
+postgresql (JDBC driver)        The PostgreSQL License
+jOOQ                            Apache-2.0
+jOOL                            Apache-2.0
+HikariCP                        Apache-2.0
+Guice                           Apache-2.0
+jCommander                      Apache-2.0
+Jackson                         Apache-2.0
+woodstox-core-asl               Apache-2.0
+json-schema-validator           Apache-2.0
+validation-api                  Apache-2.0
+hibernate-validator             Apache-2.0
+javax.el                        CDDL+GPLv2 with classpath exception
+derbyclient                     Apache-2.0
+derby                           Apache-2.0
+jsr305                          Apache-2.0
+FindBugs Annotations            LGPL-3.0
+reactive-streams                CC0
+scala-library                   BSD-3-Clause
+config                          Apache-2.0
+akka-stream_2.11                Apache-2.0
+junit                           EPL-1.0
+truth                           Apache-2.0
+hamcrest-core                   BSD-3-Clause
+mockito-core                    MIT
+Dropwizard Metrics              Apache-2.0
+HDRhistogram                    Apache-2.0
+checkstyle                      LGPL-2.1
+maven-compiler-plugin           Apache-2.0
+maven-resources-plugin          Apache-2.0
+maven-surefire-plugin           Apache-2.0
+maven-enforcer-plugin           Apache-2.0
+license-maven-plugin            Apache-2.0
+maven-checkstyle-plugin         Apache-2.0
+jacoco-maven-plugin             EPL-1.0
+docker-maven-plugin             Apache-2.0
+maven-jar-plugin                Apache-2.0
+maven-assembly-plugin           Apache-2.0
+findbugs-maven-plugin           Apache-2.0
+maven-gpg-plugin                Apache-2.0
+maven-surefire-plugin           Apache-2.0
+maven-enforcer-plugin           Apache-2.0 


### PR DESCRIPTION
```
$ mvn package

[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 3:07.577s
[INFO] Finished at: Wed Dec 21 19:21:12 CET 2016
[INFO] Final Memory: 69M/247M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.19.1:test (default-test) on project server-service: There are test failures.

$ mvn --version
Apache Maven 3.0.5
Maven home: /usr/share/maven
Java version: 1.8.0_111, vendor: Oracle Corporation
Java home: /usr/lib/jvm/java-8-openjdk-amd64/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "3.13.0-105-lowlatency", arch: "amd64", family: "unix"

$ cat server/service/target/surefire-reports/com.torodb.standalone.ToroDbBootstrapServiceTest.txt

------------------------------------------------------------------------------
Test set: com.torodb.standalone.ToroDbBootstrapServiceTest
-------------------------------------------------------------------------------
Tests run: 2, Failures: 0, Errors: 1, Skipped: 1, Time elapsed: 9.739 sec <<< FAILURE! - in com.torodb.standalone.ToroDbBootstrapServiceTest
testCreateStampedeService(com.torodb.standalone.ToroDbBootstrapServiceTest)  Time elapsed: 9.287 sec  <<< ERROR!
com.google.inject.CreationException:
Unable to create injector, see the following errors:

1) Error injecting constructor, java.lang.RuntimeException: buildTimestamp property not in ISO8601 format
at com.torodb.packaging.DefaultBuildProperties.<init>(DefaultBuildProperties.java:60)
at com.torodb.packaging.DefaultBuildProperties.class(DefaultBuildProperties.java:39)
while locating com.torodb.packaging.DefaultBuildProperties
at com.torodb.standalone.BootstrapModule.configure(BootstrapModule.java:74)
while locating com.torodb.core.BuildProperties

Caused by: java.time.format.DateTimeParseException: Text '2016-12-21T19:18:05+0100' could not be parsed at index 19
at java.time.format.DateTimeFormatter.parseResolved0(DateTimeFormatter.java:1949)
at java.time.format.DateTimeFormatter.parse(DateTimeFormatter.java:1851)
at java.time.Instant.parse(Instant.java:395)
at com.torodb.packaging.DefaultBuildProperties.<init>(DefaultBuildProperties.java:83)
```