### PR TITLE
Changed the max test timeout to 10s on MvccMetainfoRepositoryTest

### DIFF
--- a/engine/metainfo-cache/src/test/java/com/torodb/metainfo/cache/mvcc/MvccMetainfoRepositoryTest.java
+++ b/engine/metainfo-cache/src/test/java/com/torodb/metainfo/cache/mvcc/MvccMetainfoRepositoryTest.java
@@ -47,7 +47,7 @@ public class MvccMetainfoRepositoryTest {
   private final String colName = "colName";
   private final String colId = "colId";
 
-  private static final long MILLIS_TO_WAIT = 1_000;
+  private static final long MILLIS_TO_WAIT = 10_000;
 
   public MvccMetainfoRepositoryTest() {
   }


### PR DESCRIPTION
This test was making that some compilations fail on travis. The timeout
is there to stop compilations if a deadlock is found, but I guess this
failures are due to the slow machines Travis use. I changed the timeout
form 1s to 10ms. If these failures were due to a randome deadlock, they
should fail anyway.