### PR TITLE
Akka components will use slf4j instead of printing to STOUT.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -338,7 +338,7 @@
             <dependency>
                 <groupId>org.scala-lang</groupId>
                 <artifactId>scala-library</artifactId>
-                <version>2.12.0</version>
+                <version>2.12.1</version>
             </dependency>
             <dependency>
                 <groupId>com.typesafe</groupId>
@@ -348,17 +348,18 @@
             <dependency>
                 <groupId>com.typesafe.akka</groupId>
                 <artifactId>akka-stream_2.12</artifactId>
-                <version>2.4.14</version>
-<!--                <exclusions>
+                <version>2.4.16</version>
+            </dependency>
+            <dependency>
+                <groupId>com.typesafe.akka</groupId>
+                <artifactId>akka-slf4j_2.12</artifactId>
+                <version>2.4.16</version>
+                <exclusions>
                     <exclusion>
-                        <groupId>org.scala-lang</groupId>
-                        <artifactId>scala-library</artifactId>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
                     </exclusion>
-                    <exclusion>
-                        <groupId>com.typesafe</groupId>
-                        <artifactId>config</artifactId>
-                    </exclusion>
-                </exclusions>-->
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/server/main/pom.xml
+++ b/server/main/pom.xml
@@ -96,6 +96,10 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-slf4j_2.12</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/server/main/src/main/resources/application.conf
+++ b/server/main/src/main/resources/application.conf
@@ -1,0 +1,7 @@
+
+akka {
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  loglevel = "DEBUG"
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+}
+

--- a/stampede/main/pom.xml
+++ b/stampede/main/pom.xml
@@ -24,7 +24,6 @@
         <dependency>
             <groupId>com.torodb.engine</groupId>
             <artifactId>packaging-utils</artifactId>
-            <version>${torodb.engine.version}</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -39,6 +38,10 @@
             <groupId>com.torodb.engine</groupId>
             <artifactId>essential</artifactId>
             <version>${torodb.engine.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-slf4j_2.12</artifactId>
         </dependency>
         
         <dependency>

--- a/stampede/main/src/main/resources/application.conf
+++ b/stampede/main/src/main/resources/application.conf
@@ -1,0 +1,7 @@
+
+akka {
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  loglevel = "DEBUG"
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+}
+


### PR DESCRIPTION
ToroDB Server and Stampede contains a new resouce called
application.conf, used by akka to read several configurations. These
files indicates akka that it should use slf4j to log. As slf4j is
configured to delegate on log4j2, the logs send by akka will use the
same configuration as our own logs.