### PR TITLE
Bug fixed with Views 

### DIFF
--- a/engine/mongodb/mongodb-core/src/main/java/com/torodb/mongodb/commands/impl/admin/ListCollectionsImplementation.java
+++ b/engine/mongodb/mongodb-core/src/main/java/com/torodb/mongodb/commands/impl/admin/ListCollectionsImplementation.java
@@ -72,7 +72,7 @@ public class ListCollectionsImplementation implements
             CursorResult.createSingleBatchCursor(req.getDatabase(),
                 NamespaceUtil.LIST_COLLECTIONS_GET_MORE_COLLECTION,
                 context.getTorodTransaction().getCollectionsInfo(req.getDatabase()).map(colInfo ->
-                    new Entry(colInfo.getName(), DEFAULT_COLLECTION_OPTIONS)
+                    new Entry(colInfo.getName(), colInfo.getType(), DEFAULT_COLLECTION_OPTIONS)
                 )
             )
         )

--- a/engine/mongodb/mongodb-core/src/main/java/com/torodb/mongodb/commands/signatures/admin/ListCollectionsCommand.java
+++ b/engine/mongodb/mongodb-core/src/main/java/com/torodb/mongodb/commands/signatures/admin/ListCollectionsCommand.java
@@ -144,6 +144,7 @@ public class ListCollectionsCommand
     private static final DocField CURSOR_FIELD = new DocField("cursor");
     private static final StringField NAME_FIELD = new StringField("name");
     private static final DocField OPTIONS_FIELD = new DocField("options");
+    private static final StringField TYPE_FIELD = new StringField("type");
 
     private final CursorResult<Entry> cursor;
 
@@ -176,12 +177,14 @@ public class ListCollectionsCommand
     public static class Entry {
 
       private final String name;
+      private final String type;
       private final CollectionOptions options;
       public static final Function<BsonValue<?>, Entry> TO_ENTRY = new ToEntryConverter();
       public static final Function<Entry, BsonDocument> FROM_ENTRY = new FromEntryConverter();
 
-      public Entry(String name, CollectionOptions options) {
+      public Entry(String name, String type, CollectionOptions options) {
         this.name = name;
+        this.type = type;
         this.options = options;
       }
 
@@ -189,6 +192,10 @@ public class ListCollectionsCommand
         return name;
       }
 
+      public String getType() {
+        return type;
+      }
+      
       public CollectionOptions getCollectionOptions() {
         return options;
       }
@@ -207,6 +214,7 @@ public class ListCollectionsCommand
           BsonDocument doc = from.asDocument();
           return new Entry(
               BsonReaderTool.getString(doc, NAME_FIELD),
+              BsonReaderTool.getString(doc, TYPE_FIELD),              
               CollectionOptions.unmarshal(
                   BsonReaderTool.getDocument(doc, OPTIONS_FIELD)
               )

--- a/engine/mongodb/mongodb-core/src/main/java/com/torodb/mongodb/utils/ListCollectionsRequester.java
+++ b/engine/mongodb/mongodb-core/src/main/java/com/torodb/mongodb/utils/ListCollectionsRequester.java
@@ -49,8 +49,9 @@ public class ListCollectionsRequester {
       String database,
       @Nullable BsonDocument filter
   ) throws MongoException {
-    boolean commandSupported = connection.getClientOwner()
-        .getMongoVersion().compareTo(MongoVersion.V3_0) >= 0;
+    boolean commandSupported =
+        connection.getClientOwner().getMongoVersion().compareTo(MongoVersion.V3_0) >= 0
+            || connection.getClientOwner().getMongoVersion().equals(MongoVersion.UNKNOWN);
     if (commandSupported) {
       return getFromCommand(connection, database, filter);
     } else {
@@ -81,7 +82,8 @@ public class ListCollectionsRequester {
       MongoConnection connection,
       String database,
       BsonDocument filter) {
-    throw new UnsupportedOperationException("Not supported yet");
+    throw new UnsupportedOperationException(
+        "It is not supported to replicate from your MongoDB version");
   }
 
 }

--- a/engine/mongodb/mongodb-core/src/main/java/com/torodb/mongodb/utils/ListIndexesRequester.java
+++ b/engine/mongodb/mongodb-core/src/main/java/com/torodb/mongodb/utils/ListIndexesRequester.java
@@ -46,8 +46,9 @@ public class ListIndexesRequester {
       String database,
       String collection
   ) throws MongoException {
-    boolean commandSupported = connection.getClientOwner()
-        .getMongoVersion().compareTo(MongoVersion.V3_0) >= 0;
+    boolean commandSupported =
+        connection.getClientOwner().getMongoVersion().compareTo(MongoVersion.V3_0) >= 0
+            || connection.getClientOwner().getMongoVersion().equals(MongoVersion.UNKNOWN);
     if (commandSupported) {
       return getFromCommand(connection, database, collection);
     } else {
@@ -77,6 +78,7 @@ public class ListIndexesRequester {
       MongoConnection connection,
       String database,
       String collection) {
-    throw new UnsupportedOperationException("Not supported yet");
+    throw new UnsupportedOperationException(
+        "It is not supported to replicate from your MongoDB version");
   }
 }

--- a/engine/mongodb/mongodb-core/src/main/java/com/torodb/mongodb/utils/NamespaceUtil.java
+++ b/engine/mongodb/mongodb-core/src/main/java/com/torodb/mongodb/utils/NamespaceUtil.java
@@ -18,6 +18,8 @@
 
 package com.torodb.mongodb.utils;
 
+import com.torodb.torod.CollectionInfo.Type;
+
 public class NamespaceUtil {
 
   public static final String NAMESPACES_COLLECTION = "system.namespaces";
@@ -125,5 +127,9 @@ public class NamespaceUtil {
 
   public static boolean isTorodbCollection(String collection) {
     return collection.equals("torodb");
+  }
+  
+  public static boolean isViewCollection(String type) {
+    return type.equals(Type.VIEW.getValue());
   }
 }

--- a/engine/mongodb/mongodb-core/src/main/java/com/torodb/mongodb/utils/cloner/AkkaDbCloner.java
+++ b/engine/mongodb/mongodb-core/src/main/java/com/torodb/mongodb/utils/cloner/AkkaDbCloner.java
@@ -432,6 +432,11 @@ public class AkkaDbCloner extends ActorSystemTorodbService implements DbCloner {
         LOGGER.info("Not cloning {} because it didn't pass the given filter predicate", collName);
         continue;
       }
+      if (NamespaceUtil.isViewCollection(collEntry.getType())) {
+        LOGGER.info("Not cloning {} because it is a view", collName);
+        continue;
+      }
+      
       LOGGER.info("Collection {}.{} will be cloned", fromDb, collName);
       collsToClone.add(collEntry);
     }

--- a/engine/mongodb/mongodb-core/src/main/java/com/torodb/mongodb/utils/cloner/TransactionalDbCloner.java
+++ b/engine/mongodb/mongodb-core/src/main/java/com/torodb/mongodb/utils/cloner/TransactionalDbCloner.java
@@ -148,10 +148,22 @@ public class TransactionalDbCloner extends AbstractService implements DbCloner {
         LOGGER.info("Not cloning {} because is a not user writable", collName);
         continue;
       }
+      
       if (NamespaceUtil.isNormal(fromDb, collName)) {
         LOGGER.info("Not cloning {} because it is not normal", collName);
         continue;
       }
+      
+      if (!opts.getCollectionFilter().test(collName)) {
+        LOGGER.info("Not cloning {} because it didn't pass the given filter predicate", collName);
+        continue;
+      }
+      
+      if (NamespaceUtil.isViewCollection(collEntry.getType())) {
+        LOGGER.info("Not cloning {} because it is a view", collName);
+        continue;
+      }
+      
       LOGGER.info("Collection {}.{} will be cloned", fromDb, collName);
       collsToClone.put(collName, collEntry.getCollectionOptions());
     }

--- a/engine/torod/src/main/java/com/torodb/torod/CollectionInfo.java
+++ b/engine/torod/src/main/java/com/torodb/torod/CollectionInfo.java
@@ -30,16 +30,24 @@ public class CollectionInfo {
   private static final String MAX_IF_CAPPED = "maxIfCapped";
 
   private final String name;
+  private final Type type;
   private final JsonObject properties;
 
-  public CollectionInfo(@Nonnull String name, @Nonnull JsonObject properties) {
+  public CollectionInfo(@Nonnull String name, @Nonnull Type type,
+      @Nonnull JsonObject properties) {
     this.name = name;
+    this.type = type;
     this.properties = properties;
   }
 
   @Nonnull
   public String getName() {
     return name;
+  }
+
+  @Nonnull
+  public String getType() {
+    return type.getValue();
   }
 
   @Nonnull
@@ -58,5 +66,20 @@ public class CollectionInfo {
     }
 
     return properties.getInt(MAX_IF_CAPPED);
+  }
+  
+  public static enum Type {
+    COLLECTION("collection"),
+    VIEW("view");
+    
+    public final String value;
+    
+    Type(String value) {
+      this.value = value;
+    }
+    
+    public String getValue() {
+      return this.value;
+    }
   }
 }

--- a/engine/torod/src/main/java/com/torodb/torod/impl/memory/MemoryTorodTransaction.java
+++ b/engine/torod/src/main/java/com/torodb/torod/impl/memory/MemoryTorodTransaction.java
@@ -29,6 +29,7 @@ import com.torodb.core.util.AttributeRefKvDocResolver;
 import com.torodb.kvdocument.values.KvDocument;
 import com.torodb.kvdocument.values.KvValue;
 import com.torodb.torod.CollectionInfo;
+import com.torodb.torod.CollectionInfo.Type;
 import com.torodb.torod.IndexInfo;
 import com.torodb.torod.TorodTransaction;
 import com.torodb.torod.cursors.DocTorodCursor;
@@ -178,7 +179,7 @@ public abstract class MemoryTorodTransaction implements TorodTransaction {
   }
 
   private CollectionInfo getCollectionInfoPrivate(String colName) {
-    return new CollectionInfo(colName, Json.createObjectBuilder().build());
+    return new CollectionInfo(colName, Type.COLLECTION, Json.createObjectBuilder().build());
   }
 
   @Override

--- a/engine/torod/src/main/java/com/torodb/torod/impl/sql/SqlTorodTransaction.java
+++ b/engine/torod/src/main/java/com/torodb/torod/impl/sql/SqlTorodTransaction.java
@@ -40,6 +40,7 @@ import com.torodb.core.transaction.metainf.MetaField;
 import com.torodb.core.transaction.metainf.MetaIndex;
 import com.torodb.kvdocument.values.KvValue;
 import com.torodb.torod.CollectionInfo;
+import com.torodb.torod.CollectionInfo.Type;
 import com.torodb.torod.IndexInfo;
 import com.torodb.torod.TorodTransaction;
 import com.torodb.torod.cursors.EmptyTorodCursor;
@@ -324,8 +325,8 @@ public abstract class SqlTorodTransaction<T extends InternalTransaction>
       return Stream.empty();
     }
 
-    return db.streamMetaCollections()
-        .map(metaCol -> new CollectionInfo(metaCol.getName(), Json.createObjectBuilder().build()));
+    return db.streamMetaCollections().map(metaCol -> new CollectionInfo(metaCol.getName(),
+        Type.COLLECTION, Json.createObjectBuilder().build()));
   }
 
   @Override
@@ -340,7 +341,7 @@ public abstract class SqlTorodTransaction<T extends InternalTransaction>
       throw new CollectionNotFoundException(dbName, colName);
     }
 
-    return new CollectionInfo(db.getMetaCollectionByName(colName).getName(), Json
+    return new CollectionInfo(db.getMetaCollectionByName(colName).getName(), Type.COLLECTION, Json
         .createObjectBuilder().build());
   }
 


### PR DESCRIPTION
- When ToroDB start initial synchronization and get all collections for clone, also get the Views from MongoDB, and we are filter it for not cloning it and not duplicate data and get other errors. 
- Improved error message when MongoDB version is < 3.0 ( "It is not supported to replicate from your MongoDB version" ) 