### PR TITLE
Several changes to support import mode on sharding

### DIFF
--- a/engine/backend/common/src/main/java/com/torodb/backend/AbstractMetaDataWriteInterface.java
+++ b/engine/backend/common/src/main/java/com/torodb/backend/AbstractMetaDataWriteInterface.java
@@ -242,7 +242,7 @@ public abstract class AbstractMetaDataWriteInterface implements MetaDataWriteInt
       MetaIndex index, MetaIndexField field) {
     String statement = getAddMetaIndexFieldStatement(database.getName(), collection.getName(), index
         .getName(),
-        field.getPosition(), field.getTableRef(), field.getName(), field.getOrdering());
+        field.getPosition(), field.getTableRef(), field.getFieldName(), field.getOrdering());
     sqlHelper.executeUpdate(dsl, statement, Context.META_INSERT);
   }
 

--- a/engine/backend/common/src/main/java/com/torodb/backend/AbstractStructureInterface.java
+++ b/engine/backend/common/src/main/java/com/torodb/backend/AbstractStructureInterface.java
@@ -31,7 +31,6 @@ import com.torodb.core.transaction.metainf.MetaCollection;
 import com.torodb.core.transaction.metainf.MetaDatabase;
 import com.torodb.core.transaction.metainf.MetaDocPart;
 import com.torodb.core.transaction.metainf.MetaIdentifiedDocPartIndex;
-import com.torodb.core.transaction.metainf.MetaSnapshot;
 import org.apache.logging.log4j.Logger;
 import org.jooq.DSLContext;
 import org.jooq.Meta;
@@ -155,11 +154,10 @@ public abstract class AbstractStructureInterface implements StructureInterface {
       String toSchemaName);
 
   @Override
-  public void createIndex(DSLContext dsl, String indexName,
-      String schemaName, String tableName,
-      List<Tuple2<String, Boolean>> columnList, boolean unique
-  ) throws UserException {
-    if (!dbBackend.isOnDataInsertMode()) {
+  public void createIndex(DSLContext dsl, String indexName, String schemaName, String tableName,
+      List<Tuple2<String, Boolean>> columnList, boolean unique)
+      throws UserException {
+    if (!dbBackend.isOnDataInsertMode(schemaName)) {
       Preconditions.checkArgument(!columnList.isEmpty(), "Can not create index on 0 columns");
 
       String statement = getCreateIndexStatement(indexName, schemaName, tableName, columnList,
@@ -285,7 +283,7 @@ public abstract class AbstractStructureInterface implements StructureInterface {
   public Stream<Function<DSLContext, String>> streamRootDocPartTableIndexesCreation(
       String schemaName, String tableName, TableRef tableRef) {
     List<Function<DSLContext, String>> result = new ArrayList<>(1);
-    if (!dbBackend.isOnDataInsertMode()) {
+    if (!dbBackend.isOnDataInsertMode(schemaName)) {
       String primaryKeyStatement = getAddDocPartTablePrimaryKeyStatement(schemaName, tableName,
           metaDataReadInterface.getPrimaryKeyInternalFields(tableRef));
 
@@ -302,7 +300,7 @@ public abstract class AbstractStructureInterface implements StructureInterface {
   public Stream<Function<DSLContext, String>> streamDocPartTableIndexesCreation(String schemaName,
       String tableName, TableRef tableRef, String foreignTableName) {
     List<Function<DSLContext, String>> result = new ArrayList<>(4);
-    if (!dbBackend.isOnDataInsertMode()) {
+    if (!dbBackend.isOnDataInsertMode(schemaName)) {
       String primaryKeyStatement = getAddDocPartTablePrimaryKeyStatement(schemaName, tableName,
           metaDataReadInterface.getPrimaryKeyInternalFields(tableRef));
       result.add((dsl) -> {
@@ -311,7 +309,7 @@ public abstract class AbstractStructureInterface implements StructureInterface {
       });
     }
 
-    if (!dbBackend.isOnDataInsertMode()) {
+    if (!dbBackend.isOnDataInsertMode(schemaName)) {
       String readIndexStatement = getCreateDocPartTableIndexStatement(schemaName, tableName,
           metaDataReadInterface.getReadInternalFields(tableRef));
       result.add((dsl) -> {
@@ -321,7 +319,7 @@ public abstract class AbstractStructureInterface implements StructureInterface {
       });
     }
 
-    if (!dbBackend.isOnDataInsertMode()) {
+    if (!dbBackend.isOnDataInsertMode(schemaName)) {
       if (dbBackend.includeForeignKeys()) {
         String foreignKeyStatement = getAddDocPartTableForeignKeyStatement(schemaName, tableName,
             metaDataReadInterface.getReferenceInternalFields(tableRef),
@@ -349,7 +347,7 @@ public abstract class AbstractStructureInterface implements StructureInterface {
   }
 
   @Override
-  public Stream<Function<DSLContext, String>> streamDataInsertFinishTasks(MetaSnapshot snapshot) {
+  public Stream<Function<DSLContext, String>> streamDataInsertFinishTasks(MetaDatabase db) {
     return Collections.<Function<DSLContext, String>>emptySet().stream();
   }
 

--- a/engine/backend/common/src/main/java/com/torodb/backend/DbBackendService.java
+++ b/engine/backend/common/src/main/java/com/torodb/backend/DbBackendService.java
@@ -19,6 +19,7 @@
 package com.torodb.backend;
 
 import com.torodb.core.services.TorodbService;
+import com.torodb.core.transaction.metainf.MetaDatabase;
 
 import java.sql.Connection;
 
@@ -32,11 +33,23 @@ public interface DbBackendService extends TorodbService {
 
   public DataSource getGlobalCursorDatasource();
 
-  public void disableDataInsertMode();
+  public void disableDataInsertMode(String schemaName);
 
-  public void enableDataInsertMode();
+  public default void disableDataInsertMode(MetaDatabase db) {
+    disableDataInsertMode(db.getIdentifier());
+  }
 
-  public boolean isOnDataInsertMode();
+  public void enableDataInsertMode(String schemaName);
+
+  public default void enableDataInsertMode(MetaDatabase db) {
+    enableDataInsertMode(db.getIdentifier());
+  }
+
+  public boolean isOnDataInsertMode(String schemaName);
+
+  public default boolean isOnDataInsertMode(MetaDatabase db) {
+    return isOnDataInsertMode(db.getIdentifier());
+  }
 
   public boolean includeForeignKeys();
 

--- a/engine/backend/common/src/main/java/com/torodb/backend/ExclusiveWriteBackendTransactionImpl.java
+++ b/engine/backend/common/src/main/java/com/torodb/backend/ExclusiveWriteBackendTransactionImpl.java
@@ -128,7 +128,7 @@ public class ExclusiveWriteBackendTransactionImpl extends SharedWriteBackendTran
       MetaIndexField fromMetaIndexField = fromMetaIndexFieldIterator.next();
       MetaIndexField toMetaIndexField = toMetaIndex.addMetaIndexField(
           fromMetaIndexField.getTableRef(),
-          fromMetaIndexField.getName(),
+          fromMetaIndexField.getFieldName(),
           fromMetaIndexField.getOrdering());
       getSqlInterface().getMetaDataWriteInterface().addMetaIndexField(
           getDsl(), toMetaDb, toMetaColl, toMetaIndex, toMetaIndexField);

--- a/engine/backend/common/src/main/java/com/torodb/backend/StructureInterface.java
+++ b/engine/backend/common/src/main/java/com/torodb/backend/StructureInterface.java
@@ -25,7 +25,6 @@ import com.torodb.core.exceptions.InvalidDatabaseException;
 import com.torodb.core.exceptions.user.UserException;
 import com.torodb.core.transaction.metainf.MetaCollection;
 import com.torodb.core.transaction.metainf.MetaDatabase;
-import com.torodb.core.transaction.metainf.MetaSnapshot;
 import org.jooq.DSLContext;
 import org.jooq.Meta;
 import org.jooq.Schema;
@@ -97,13 +96,10 @@ public interface StructureInterface {
    * be done once the data insert mode finishes and return a label that indicate the type of
    * operation executed.
    *
-   * For example, PostgreSQL backend would like to run analyze on the modified tables to get some
+   * <p>For example, PostgreSQL backend would like to run analyze on the modified tables to get some
    * stadistics.
-   *
-   * @param snapshot
-   * @return
    */
-  public Stream<Function<DSLContext, String>> streamDataInsertFinishTasks(MetaSnapshot snapshot);
+  public Stream<Function<DSLContext, String>> streamDataInsertFinishTasks(MetaDatabase db);
 
   void createIndex(@Nonnull DSLContext dsl, @Nonnull String indexName, @Nonnull String tableSchema,
       @Nonnull String tableName, @Nonnull List<Tuple2<String, Boolean>> columnList, boolean unique)

--- a/engine/backend/postgresql/src/main/java/com/torodb/backend/postgresql/PostgreSqlStructureInterface.java
+++ b/engine/backend/postgresql/src/main/java/com/torodb/backend/postgresql/PostgreSqlStructureInterface.java
@@ -29,7 +29,6 @@ import com.torodb.core.backend.IdentifierConstraints;
 import com.torodb.core.transaction.metainf.MetaCollection;
 import com.torodb.core.transaction.metainf.MetaDatabase;
 import com.torodb.core.transaction.metainf.MetaDocPart;
-import com.torodb.core.transaction.metainf.MetaSnapshot;
 import org.jooq.DSLContext;
 import org.jooq.lambda.tuple.Tuple2;
 
@@ -221,12 +220,10 @@ public class PostgreSqlStructureInterface extends AbstractStructureInterface {
   }
 
   @Override
-  public Stream<Function<DSLContext, String>> streamDataInsertFinishTasks(MetaSnapshot snapshot) {
-    return snapshot.streamMetaDatabases().flatMap(
-        db -> db.streamMetaCollections().flatMap(
-            col -> col.streamContainedMetaDocParts().map(
-                docPart -> createAnalyzeConsumer(db, col, docPart)
-            )
+  public Stream<Function<DSLContext, String>> streamDataInsertFinishTasks(MetaDatabase db) {
+    return db.streamMetaCollections().flatMap(
+        col -> col.streamContainedMetaDocParts().map(
+            docPart -> createAnalyzeConsumer(db, col, docPart)
         )
     );
   }

--- a/engine/common/src/main/java/com/torodb/common/util/Empty.java
+++ b/engine/common/src/main/java/com/torodb/common/util/Empty.java
@@ -1,0 +1,48 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.common.util;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * This class is like {@link Void} but it has one instance.
+ * <p/>
+ * This can be useful when you want an implementation of a generic class that returns non null
+ * instances of the generic type. For instance, commands that do not need argument or do not return
+ * information, can use this class.
+ */
+public class Empty {
+
+  private Empty() {
+  }
+
+  public static Empty getInstance() {
+    return EmptyHolder.INSTANCE;
+  }
+
+  private static class EmptyHolder {
+
+    private static final Empty INSTANCE = new Empty();
+  }
+
+  @SuppressFBWarnings(value = "UPM_UNCALLED_PRIVATE_METHOD")
+  private Object readResolve() {
+    return Empty.getInstance();
+  }
+}

--- a/engine/core/src/main/java/com/torodb/core/backend/BackendService.java
+++ b/engine/core/src/main/java/com/torodb/core/backend/BackendService.java
@@ -19,8 +19,11 @@
 package com.torodb.core.backend;
 
 import com.google.common.util.concurrent.Service;
+import com.torodb.common.util.Empty;
 import com.torodb.core.transaction.RollbackException;
-import com.torodb.core.transaction.metainf.MetaSnapshot;
+import com.torodb.core.transaction.metainf.MetaDatabase;
+
+import java.util.concurrent.CompletableFuture;
 
 public interface BackendService extends Service {
 
@@ -31,21 +34,20 @@ public interface BackendService extends Service {
    *
    * <p>This method can be quite slow, as it is usual to execute quite expensive low level task like
    * recreate indexes.
-   *
-   * @param snapshot the meta data snapshot.
    */
-  public void disableDataImportMode(MetaSnapshot snapshot) throws RollbackException;
+  public CompletableFuture<Empty> disableDataImportMode(MetaDatabase metaDb)
+      throws RollbackException;
 
   /**
    * Sets the backend on a state where inserts are faster.
    *
-   * <p>During this state, only metadata operations and inserts are supported (but it is not
+   * <p/> During this state, only metadata operations and inserts are supported (but it is not
    * mandatory to throw an exception if other operations are recived). It is expected that each
    * call to this method is follow by a call to
-   * {@link #enableDataImportMode(com.torodb.core.transaction.metainf.MetaSnapshot) }, which will
-   * enable the default mode.
-   *
-   * @param snapshot the meta data snapshot.
+   * {@link #enableDataImportMode(com.torodb.core.transaction.metainf.MetaSnapshot,
+   * com.torodb.core.transaction.metainf.MetaDatabase) },
+   * which will enable the default mode.
    */
-  public void enableDataImportMode(MetaSnapshot snapshot) throws RollbackException;
+  public CompletableFuture<Empty> enableDataImportMode(MetaDatabase metaDb)
+      throws RollbackException;
 }

--- a/engine/core/src/main/java/com/torodb/core/backend/WriteBackendTransaction.java
+++ b/engine/core/src/main/java/com/torodb/core/backend/WriteBackendTransaction.java
@@ -35,7 +35,7 @@ import com.torodb.kvdocument.values.KvValue;
 import java.util.Collection;
 
 public interface WriteBackendTransaction extends BackendTransaction {
-
+  
   /**
    * Adds a new database.
    *

--- a/engine/core/src/main/java/com/torodb/core/concurrent/StreamExecutor.java
+++ b/engine/core/src/main/java/com/torodb/core/concurrent/StreamExecutor.java
@@ -19,6 +19,7 @@
 package com.torodb.core.concurrent;
 
 import com.google.common.util.concurrent.Service;
+import com.torodb.common.util.Empty;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -39,7 +40,7 @@ public interface StreamExecutor extends Service {
    * @param runnables
    * @return a CompletableFuture that will be done on once all runnables finish.
    */
-  public CompletableFuture<?> executeRunnables(Stream<Runnable> runnables);
+  public CompletableFuture<Empty> executeRunnables(Stream<Runnable> runnables);
 
   /**
    * Executes the given callables, returning a future that will be done once all callables finish.
@@ -49,7 +50,7 @@ public interface StreamExecutor extends Service {
    * @param callables
    * @return a CompletableFuture that will be done on once all callables finish.
    */
-  public <I> CompletableFuture<?> execute(Stream<Callable<I>> callables);
+  public <I> CompletableFuture<Empty> execute(Stream<Callable<I>> callables);
 
   /**
    * Executes the given callables, returning a future that will be done once all callables finish.

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/ChangedElement.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/ChangedElement.java
@@ -1,0 +1,30 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.core.transaction.metainf;
+
+/**
+ *
+ */
+public interface ChangedElement<E> {
+
+  public E getElement();
+
+  public MetaElementState getChange();
+
+}

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaCollection.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaCollection.java
@@ -119,6 +119,11 @@ public class ImmutableMetaCollection implements MetaCollection {
     return getMissingIndexesForNewField(streamContainedMetaIndexes(), docPart, newField);
   }
 
+  @Override
+  public ImmutableMetaCollection immutableCopy() {
+    return this;
+  }
+
   protected List<Tuple2<MetaIndex, List<String>>> getMissingIndexesForNewField(
       Stream<? extends MetaIndex> containedMetaIndexes,
       MutableMetaDocPart docPart, MetaField newField) {

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaCollection.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaCollection.java
@@ -114,14 +114,14 @@ public class ImmutableMetaCollection implements MetaCollection {
   }
 
   @Override
-  public List<Tuple2<MetaIndex, List<String>>> getMissingIndexesForNewField(
-      MutableMetaDocPart docPart, MetaField newField) {
-    return getMissingIndexesForNewField(streamContainedMetaIndexes(), docPart, newField);
+  public ImmutableMetaCollection immutableCopy() {
+    return this;
   }
 
   @Override
-  public ImmutableMetaCollection immutableCopy() {
-    return this;
+  public List<Tuple2<MetaIndex, List<String>>> getMissingIndexesForNewField(
+      MutableMetaDocPart docPart, MetaField newField) {
+    return getMissingIndexesForNewField(streamContainedMetaIndexes(), docPart, newField);
   }
 
   protected List<Tuple2<MetaIndex, List<String>>> getMissingIndexesForNewField(
@@ -132,7 +132,7 @@ public class ImmutableMetaCollection implements MetaCollection {
             .getName()) != null)
         .flatMap(index -> Seq.seq(index.iteratorMetaDocPartIndexesIdentifiers(docPart))
             .filter(identifiers -> identifiers.contains(newField.getIdentifier()))
-            .map(identifiers -> new Tuple2<MetaIndex, List<String>>(index, identifiers)))
+            .map(identifiers -> new Tuple2<>(index, identifiers)))
         .collect(Collectors.groupingBy(missingIndexEntry -> missingIndexEntry.v2()))
         .entrySet()
         .stream()

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaDatabase.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaDatabase.java
@@ -89,6 +89,10 @@ public class ImmutableMetaDatabase implements MetaDatabase {
     return defautToString();
   }
 
+  public ImmutableMetaDatabase immutableCopy() {
+    return this;
+  }
+
   public static class Builder {
 
     private boolean built = false;

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaDocPart.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaDocPart.java
@@ -117,6 +117,11 @@ public class ImmutableMetaDocPart implements MetaDocPart {
     return defautToString();
   }
 
+  @Override
+  public ImmutableMetaDocPart immutableCopy() {
+    return this;
+  }
+
   public static class Builder {
 
     private boolean built = false;

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaDocPartIndexColumn.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaDocPartIndexColumn.java
@@ -53,6 +53,11 @@ public class ImmutableMetaDocPartIndexColumn implements MetaDocPartIndexColumn {
   }
 
   @Override
+  public ImmutableMetaDocPartIndexColumn immutableCopy() {
+    return this;
+  }
+
+  @Override
   public String toString() {
     return defautToString();
   }

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaField.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaField.java
@@ -52,6 +52,11 @@ public class ImmutableMetaField implements MetaField {
   }
 
   @Override
+  public ImmutableMetaField immutableCopy() {
+    return this;
+  }
+
+  @Override
   public String toString() {
     return defautToString();
   }

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaFieldIndex.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaFieldIndex.java
@@ -60,6 +60,11 @@ public class ImmutableMetaFieldIndex implements MetaFieldIndex {
   }
 
   @Override
+  public ImmutableMetaFieldIndex immutableCopy() {
+    return this;
+  }
+
+  @Override
   public String toString() {
     return defautToString();
   }

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaIdentifiedDocPartIndex.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaIdentifiedDocPartIndex.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 /**
  *
@@ -62,6 +63,11 @@ public class ImmutableMetaIdentifiedDocPartIndex extends AbstractMetaDocPartInde
   }
 
   @Override
+  public Stream<? extends MetaDocPartIndexColumn> streamColumns() {
+    return columnsByPosition.stream();
+  }
+
+  @Override
   public Iterator<ImmutableMetaDocPartIndexColumn> iteratorColumns() {
     return columnsByPosition.iterator();
   }
@@ -79,6 +85,11 @@ public class ImmutableMetaIdentifiedDocPartIndex extends AbstractMetaDocPartInde
   @Override
   public ImmutableMetaIdentifiedDocPartIndex immutableCopy(String identifier) throws
       IllegalArgumentException {
+    return this;
+  }
+
+  @Override
+  public ImmutableMetaIdentifiedDocPartIndex immutableCopy() {
     return this;
   }
 

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaIdentifiedDocPartIndex.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaIdentifiedDocPartIndex.java
@@ -77,6 +77,12 @@ public class ImmutableMetaIdentifiedDocPartIndex extends AbstractMetaDocPartInde
   }
 
   @Override
+  public ImmutableMetaIdentifiedDocPartIndex immutableCopy(String identifier) throws
+      IllegalArgumentException {
+    return this;
+  }
+
+  @Override
   public String toString() {
     return defautToString();
   }

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaIndex.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaIndex.java
@@ -129,6 +129,11 @@ public class ImmutableMetaIndex implements MetaIndex {
   }
 
   @Override
+  public ImmutableMetaIndex immutableCopy() {
+    return this;
+  }
+
+  @Override
   public boolean isCompatible(MetaDocPart docPart) {
     return isCompatible(docPart,
         iteratorMetaIndexFieldByTableRef(docPart.getTableRef()));

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaIndexField.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaIndexField.java
@@ -137,4 +137,9 @@ public class ImmutableMetaIndexField implements MetaIndexField {
         getName()) && otherIndexField.getOrdering() == getOrdering();
   }
 
+  @Override
+  public ImmutableMetaIndexField immutableCopy() {
+    return this;
+  }
+
 }

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaIndexField.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaIndexField.java
@@ -55,7 +55,7 @@ public class ImmutableMetaIndexField implements MetaIndexField {
   }
 
   @Override
-  public String getName() {
+  public String getFieldName() {
     return name;
   }
 
@@ -133,8 +133,9 @@ public class ImmutableMetaIndexField implements MetaIndexField {
 
   @Override
   public boolean isMatch(MetaIndexField otherIndexField) {
-    return otherIndexField.getTableRef().equals(getTableRef()) && otherIndexField.getName().equals(
-        getName()) && otherIndexField.getOrdering() == getOrdering();
+    return otherIndexField.getTableRef().equals(getTableRef()) 
+        && otherIndexField.getFieldName().equals(getFieldName())
+        && otherIndexField.getOrdering() == getOrdering();
   }
 
   @Override

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaScalar.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaScalar.java
@@ -44,6 +44,11 @@ public class ImmutableMetaScalar implements MetaScalar {
   }
 
   @Override
+  public ImmutableMetaScalar immutableCopy() {
+    return this;
+  }
+
+  @Override
   public int hashCode() {
     int hash = 7;
     hash = 97 * hash + Objects.hashCode(this.type);

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaSnapshot.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaSnapshot.java
@@ -68,6 +68,11 @@ public class ImmutableMetaSnapshot implements MetaSnapshot {
     return dbsByIdentifier.get(schemaDbName);
   }
 
+  @Override
+  public ImmutableMetaSnapshot immutableCopy() {
+    return this;
+  }
+
   public static class Builder {
 
     private boolean built = false;

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaSnapshot.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/ImmutableMetaSnapshot.java
@@ -59,8 +59,8 @@ public class ImmutableMetaSnapshot implements MetaSnapshot {
   }
 
   @Override
-  public ImmutableMetaDatabase getMetaDatabaseByName(String schemaDocName) {
-    return dbsByName.get(schemaDocName);
+  public ImmutableMetaDatabase getMetaDatabaseByName(String dbName) {
+    return dbsByName.get(dbName);
   }
 
   @Override

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaCollection.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaCollection.java
@@ -27,8 +27,6 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-/**
- */
 public interface MetaCollection {
 
   /**
@@ -66,5 +64,7 @@ public interface MetaCollection {
   public default String defautToString() {
     return "col{" + "name:" + getName() + ", id:" + getIdentifier() + '}';
   }
+
+  public ImmutableMetaCollection immutableCopy();
 
 }

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaDatabase.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaDatabase.java
@@ -23,9 +23,6 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-/**
- *
- */
 public interface MetaDatabase {
 
   /**
@@ -55,5 +52,7 @@ public interface MetaDatabase {
   public default String defautToString() {
     return "db{" + "name:" + getName() + ", id:" + getIdentifier() + '}';
   }
+
+  public abstract ImmutableMetaDatabase immutableCopy();
 
 }

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaDocPart.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaDocPart.java
@@ -26,8 +26,6 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-/**
- */
 public interface MetaDocPart {
 
   @Nonnull
@@ -102,4 +100,6 @@ public interface MetaDocPart {
   public default String defautToString() {
     return "docPart{" + "ref:" + getTableRef() + ", id:" + getIdentifier() + '}';
   }
+
+  public abstract ImmutableMetaDocPart immutableCopy();
 }

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaDocPartIndex.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaDocPartIndex.java
@@ -19,6 +19,7 @@
 package com.torodb.core.transaction.metainf;
 
 import java.util.Iterator;
+import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
@@ -30,7 +31,11 @@ public interface MetaDocPartIndex {
 
   public abstract int size();
 
-  public abstract Iterator<? extends MetaDocPartIndexColumn> iteratorColumns();
+  public abstract Stream<? extends MetaDocPartIndexColumn> streamColumns();
+
+  public default Iterator<? extends MetaDocPartIndexColumn> iteratorColumns() {
+    return streamColumns().iterator();
+  }
 
   @Nullable
   public abstract MetaDocPartIndexColumn getMetaDocPartIndexColumnByPosition(int position);

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaDocPartIndex.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaDocPartIndex.java
@@ -44,4 +44,11 @@ public interface MetaDocPartIndex {
     return "docPartIndex{" + "unique:" + isUnique() + '}';
   }
 
+  /**
+   * @throws IllegalArgumentException if this index does not contains all column from position 0 to
+   *                                  the position for the column with maximum position
+   */
+  public abstract ImmutableMetaIdentifiedDocPartIndex immutableCopy(String identifier) throws
+      IllegalArgumentException;
+
 }

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaDocPartIndexColumn.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaDocPartIndexColumn.java
@@ -43,4 +43,6 @@ public interface MetaDocPartIndexColumn {
     return "fieldIndex{" + "position:" + getPosition() + ", identifier:" + getIdentifier()
         + ", ordering:" + getOrdering() + '}';
   }
+
+  public abstract ImmutableMetaDocPartIndexColumn immutableCopy();
 }

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaField.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaField.java
@@ -47,4 +47,6 @@ public interface MetaField {
   public default String defautToString() {
     return "field{" + "name:" + getName() + ", type:" + getType() + ", id:" + getIdentifier() + '}';
   }
+
+  public abstract ImmutableMetaField immutableCopy();
 }

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaFieldIndex.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaFieldIndex.java
@@ -46,4 +46,6 @@ public interface MetaFieldIndex {
     return "fieldIndex{" + "position:" + getPosition() + ", name:" + getName() + ", type:"
         + getType() + ", ordering:" + getOrdering() + '}';
   }
+
+  public abstract ImmutableMetaFieldIndex immutableCopy();
 }

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaIdentifiedDocPartIndex.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaIdentifiedDocPartIndex.java
@@ -20,17 +20,15 @@ package com.torodb.core.transaction.metainf;
 
 import javax.annotation.Nonnull;
 
-/**
- */
 public interface MetaIdentifiedDocPartIndex extends MetaDocPartIndex {
 
   /**
    * The identifier MetaDocPart on the SQL model.
-   *
-   * @return
    */
   @Nonnull
   public abstract String getIdentifier();
+
+  public abstract ImmutableMetaIdentifiedDocPartIndex immutableCopy();
 
   public default String defautToString() {
     return "docPartIndex{" + "id:" + getIdentifier() + ", unique:" + isUnique() + '}';

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaIndex.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaIndex.java
@@ -32,9 +32,7 @@ import javax.annotation.Nullable;
 public interface MetaIndex {
 
   /**
-   * The name of the index on the doc model.
-   *
-   * @return
+   * The name of the index on the document model.
    */
   @Nonnull
   public abstract String getName();
@@ -45,6 +43,10 @@ public interface MetaIndex {
 
   public abstract Iterator<? extends MetaIndexField> iteratorFields();
 
+  /**
+   * Returns an iterator that iterates over all {@link MetaIndexField} contained by this object
+   * whose {@link MetaIndexField#getTableRef() table ref} is the given by argument.
+   */
   public abstract Iterator<? extends ImmutableMetaIndexField> iteratorMetaIndexFieldByTableRef(
       TableRef tableRef);
 
@@ -69,6 +71,9 @@ public interface MetaIndex {
   public abstract boolean isMatch(MetaDocPart docPart, List<String> identifiers,
       MetaDocPartIndex docPartIndex);
 
+  /**
+   * Returns true iff the given index has the same name OR has the same fields that this one.
+   */
   public abstract boolean isMatch(MetaIndex index);
 
   public abstract boolean isSubMatch(MetaDocPart docPart, List<String> identifiersSublist,

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaIndex.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaIndex.java
@@ -78,4 +78,6 @@ public interface MetaIndex {
     return "index{" + "name:" + getName() + ", unique:" + isUnique() + '}';
   }
 
+  public abstract ImmutableMetaIndex immutableCopy();
+
 }

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaIndexField.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaIndexField.java
@@ -57,4 +57,6 @@ public interface MetaIndexField {
     return "indexField{" + "position:" + getPosition() + ", tableRef:" + getTableRef() + ", name:"
         + getName() + ", ordering:" + getOrdering() + '}';
   }
+
+  public ImmutableMetaIndexField immutableCopy();
 }

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaIndexField.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaIndexField.java
@@ -23,7 +23,7 @@ import com.torodb.core.TableRef;
 import javax.annotation.Nonnull;
 
 /**
- *
+ * A representation of a indexed field on the document model.
  */
 public interface MetaIndexField {
 
@@ -35,11 +35,9 @@ public interface MetaIndexField {
 
   /**
    * The name of the field to index on the document model.
-   *
-   * @return
    */
   @Nonnull
-  public abstract String getName();
+  public abstract String getFieldName();
 
   @Nonnull
   public abstract FieldIndexOrdering getOrdering();
@@ -55,7 +53,7 @@ public interface MetaIndexField {
 
   public default String defautToString() {
     return "indexField{" + "position:" + getPosition() + ", tableRef:" + getTableRef() + ", name:"
-        + getName() + ", ordering:" + getOrdering() + '}';
+        + getFieldName() + ", ordering:" + getOrdering() + '}';
   }
 
   public ImmutableMetaIndexField immutableCopy();

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaScalar.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaScalar.java
@@ -38,4 +38,6 @@ public interface MetaScalar {
     return "field{type:" + getType() + ", id:" + getIdentifier() + '}';
   }
 
+  public ImmutableMetaScalar immutableCopy();
+
 }

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaSnapshot.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/MetaSnapshot.java
@@ -20,6 +20,7 @@ package com.torodb.core.transaction.metainf;
 
 import java.util.stream.Stream;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -34,4 +35,7 @@ public interface MetaSnapshot {
 
   @Nullable
   public MetaDatabase getMetaDatabaseByIdentifier(String dbIdentifier);
+
+  @Nonnull
+  public abstract ImmutableMetaSnapshot immutableCopy();
 }

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/MutableMetaCollection.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/MutableMetaCollection.java
@@ -76,6 +76,4 @@ public interface MutableMetaCollection extends MetaCollection {
 
   public Optional<? extends MetaIdentifiedDocPartIndex> getAnyOrphanDocPartIndex(
       ImmutableMetaCollection oldStructure, MutableMetaIndex changed);
-
-  public abstract ImmutableMetaCollection immutableCopy();
 }

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/MutableMetaCollection.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/MutableMetaCollection.java
@@ -19,8 +19,6 @@
 package com.torodb.core.transaction.metainf;
 
 import com.torodb.core.TableRef;
-import com.torodb.core.annotations.DoNotChange;
-import org.jooq.lambda.tuple.Tuple2;
 
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -29,6 +27,11 @@ import java.util.stream.Stream;
  *
  */
 public interface MutableMetaCollection extends MetaCollection {
+
+  /**
+   * Returns the {@link ImmutableMetaCollection} from which this one derivates.
+   */
+  public ImmutableMetaCollection getOrigin();
 
   @Override
   public MutableMetaDocPart getMetaDocPartByTableRef(TableRef tableRef);
@@ -45,8 +48,7 @@ public interface MutableMetaCollection extends MetaCollection {
   public MutableMetaDocPart addMetaDocPart(TableRef tableRef, String identifier) throws
       IllegalArgumentException;
 
-  @DoNotChange
-  public Iterable<? extends MutableMetaDocPart> getModifiedMetaDocParts();
+  public Stream<? extends MutableMetaDocPart> streamModifiedMetaDocParts();
 
   @Override
   public Stream<? extends MutableMetaIndex> streamContainedMetaIndexes();
@@ -55,21 +57,14 @@ public interface MutableMetaCollection extends MetaCollection {
 
   public boolean removeMetaIndexByName(String indexName);
 
-  @DoNotChange
-  public Iterable<Tuple2<MutableMetaIndex, MetaElementState>> getModifiedMetaIndexes();
+  public Stream<ChangedElement<MutableMetaIndex>> streamModifiedMetaIndexes();
 
-  public Optional<? extends MetaIndex> getAnyMissedIndex(MetaCollection oldCol,
-      MutableMetaDocPart newStructure, ImmutableMetaDocPart oldStructure,
-      ImmutableMetaField newField);
-
-  public Optional<ImmutableMetaIndex> getAnyMissedIndex(ImmutableMetaCollection oldCol,
-      ImmutableMetaIdentifiedDocPartIndex newRemovedDocPartIndex);
-
-  public Optional<? extends MetaIndex> getAnyRelatedIndex(ImmutableMetaCollection oldCol,
-      MetaDocPart newStructure, ImmutableMetaIdentifiedDocPartIndex newDocPartIndex);
-
-  public Optional<ImmutableMetaIndex> getAnyConflictingIndex(
-      ImmutableMetaCollection oldStructure, MutableMetaIndex changed);
+  public default Optional<ChangedElement<MutableMetaIndex>> getModifiedMetaIndexByName(
+      String idxName) {
+    return streamModifiedMetaIndexes()
+        .filter(change -> change.getElement().getName().equals(idxName))
+        .findAny();
+  }
 
   public Optional<ImmutableMetaDocPart> getAnyDocPartWithMissedDocPartIndex(
       ImmutableMetaCollection oldStructure, MutableMetaIndex changed);

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/MutableMetaDatabase.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/MutableMetaDatabase.java
@@ -60,6 +60,4 @@ public interface MutableMetaDatabase extends MetaDatabase {
   @SuppressWarnings("checkstyle:LineLength")
   public abstract Iterable<Tuple2<MutableMetaCollection, MetaElementState>> getModifiedCollections();
 
-  public abstract ImmutableMetaDatabase immutableCopy();
-
 }

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/MutableMetaDatabase.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/MutableMetaDatabase.java
@@ -18,8 +18,6 @@
 
 package com.torodb.core.transaction.metainf;
 
-import com.torodb.core.annotations.DoNotChange;
-import org.jooq.lambda.tuple.Tuple2;
 
 import java.util.stream.Stream;
 
@@ -27,6 +25,11 @@ import java.util.stream.Stream;
  *
  */
 public interface MutableMetaDatabase extends MetaDatabase {
+
+  /**
+   * Returns the {@link ImmutableMetaDatabase} from which this one derivates.
+   */
+  public ImmutableMetaDatabase getOrigin();
 
   @Override
   public MutableMetaCollection getMetaCollectionByIdentifier(String collectionIdentifier);
@@ -56,8 +59,6 @@ public interface MutableMetaDatabase extends MetaDatabase {
    */
   public abstract boolean removeMetaCollectionByIdentifier(String collectionId);
 
-  @DoNotChange
-  @SuppressWarnings("checkstyle:LineLength")
-  public abstract Iterable<Tuple2<MutableMetaCollection, MetaElementState>> getModifiedCollections();
+  public abstract Stream<ChangedElement<MutableMetaCollection>> streamModifiedCollections();
 
 }

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/MutableMetaDocPart.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/MutableMetaDocPart.java
@@ -103,6 +103,4 @@ public interface MutableMetaDocPart extends MetaDocPart {
 
   public MutableMetaDocPartIndex getOrCreatePartialMutableDocPartIndexForMissingIndexAndNewField(
       MetaIndex missingIndex, List<String> identifiers, MetaField newField);
-
-  public abstract ImmutableMetaDocPart immutableCopy();
 }

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/MutableMetaDocPart.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/MutableMetaDocPart.java
@@ -19,7 +19,6 @@
 package com.torodb.core.transaction.metainf;
 
 import com.torodb.core.annotations.DoNotChange;
-import org.jooq.lambda.tuple.Tuple2;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -70,13 +69,11 @@ public interface MutableMetaDocPart extends MetaDocPart {
   public abstract ImmutableMetaScalar addMetaScalar(String identifier, FieldType type) throws
       IllegalArgumentException;
 
-  @DoNotChange
-  public abstract Iterable<? extends ImmutableMetaField> getAddedMetaFields();
+  public abstract Stream<? extends ImmutableMetaField> streamAddedMetaFields();
 
   public abstract ImmutableMetaField getAddedFieldByIdentifier(String identifier);
 
-  @DoNotChange
-  public abstract Iterable<? extends ImmutableMetaScalar> getAddedMetaScalars();
+  public abstract Stream<? extends ImmutableMetaScalar> streamAddedMetaScalars();
 
   /**
    * Add a non existent index to this doc part
@@ -94,9 +91,8 @@ public interface MutableMetaDocPart extends MetaDocPart {
    */
   public boolean removeMetaDocPartIndexByIdentifier(String indexId);
 
-  @DoNotChange
   @SuppressWarnings("checkstyle:LineLength")
-  public Iterable<Tuple2<ImmutableMetaIdentifiedDocPartIndex, MetaElementState>> getModifiedMetaDocPartIndexes();
+  public Stream<ChangedElement<ImmutableMetaIdentifiedDocPartIndex>> streamModifiedMetaDocPartIndexes();
 
   @DoNotChange
   public Iterable<MutableMetaDocPartIndex> getAddedMutableMetaDocPartIndexes();

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/MutableMetaDocPartIndex.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/MutableMetaDocPartIndex.java
@@ -18,9 +18,9 @@
 
 package com.torodb.core.transaction.metainf;
 
-import com.torodb.core.annotations.DoNotChange;
 
 import java.util.Iterator;
+import java.util.stream.Stream;
 
 /**
  *
@@ -59,7 +59,6 @@ public interface MutableMetaDocPartIndex extends MetaDocPartIndex {
   public abstract ImmutableMetaDocPartIndexColumn addMetaDocPartIndexColumn(String identifier,
       FieldIndexOrdering ordering) throws IllegalArgumentException;
 
-  @DoNotChange
   @SuppressWarnings("checkstyle:LineLength")
-  public abstract Iterable<? extends ImmutableMetaDocPartIndexColumn> getAddedMetaDocPartIndexColumns();
+  public Stream<? extends ImmutableMetaDocPartIndexColumn> streamAddedMetaDocPartIndexColumns();
 }

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/MutableMetaDocPartIndex.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/MutableMetaDocPartIndex.java
@@ -62,11 +62,4 @@ public interface MutableMetaDocPartIndex extends MetaDocPartIndex {
   @DoNotChange
   @SuppressWarnings("checkstyle:LineLength")
   public abstract Iterable<? extends ImmutableMetaDocPartIndexColumn> getAddedMetaDocPartIndexColumns();
-
-  /**
-   * @throws IllegalArgumentException if this index does not contains all column from position 0 to
-   *                                  the position for the column with maximum position
-   */
-  public abstract ImmutableMetaIdentifiedDocPartIndex immutableCopy(String identifier) throws
-      IllegalArgumentException;
 }

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/MutableMetaIndex.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/MutableMetaIndex.java
@@ -58,6 +58,4 @@ public interface MutableMetaIndex extends MetaIndex {
 
   @DoNotChange
   public abstract Iterable<? extends ImmutableMetaIndexField> getAddedMetaIndexFields();
-
-  public abstract ImmutableMetaIndex immutableCopy();
 }

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/MutableMetaIndex.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/MutableMetaIndex.java
@@ -22,13 +22,12 @@ import com.torodb.core.TableRef;
 import com.torodb.core.annotations.DoNotChange;
 
 import java.util.Iterator;
+import java.util.stream.Stream;
 
 /**
  *
  */
 public interface MutableMetaIndex extends MetaIndex {
-
-  public abstract boolean isUnique();
 
   @Override
   public ImmutableMetaIndexField getMetaIndexFieldByPosition(int position);
@@ -57,5 +56,5 @@ public interface MutableMetaIndex extends MetaIndex {
       FieldIndexOrdering ordering) throws IllegalArgumentException;
 
   @DoNotChange
-  public abstract Iterable<? extends ImmutableMetaIndexField> getAddedMetaIndexFields();
+  public Stream<? extends ImmutableMetaIndexField> streamAddedMetaIndexFields();
 }

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/MutableMetaSnapshot.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/MutableMetaSnapshot.java
@@ -19,7 +19,6 @@
 package com.torodb.core.transaction.metainf;
 
 import com.torodb.core.annotations.DoNotChange;
-import org.jooq.lambda.tuple.Tuple2;
 
 import java.util.stream.Stream;
 
@@ -28,9 +27,13 @@ import javax.annotation.Nullable;
 
 /**
  *
- * @param <MMD>
  */
 public interface MutableMetaSnapshot extends MetaSnapshot {
+
+  /**
+   * Returns the {@link ImmutableMetaSnapshot} from which this one derivates.
+   */
+  public ImmutableMetaSnapshot getOrigin();
 
   @Override
   @Nullable
@@ -64,7 +67,7 @@ public interface MutableMetaSnapshot extends MetaSnapshot {
   public abstract boolean removeMetaDatabaseByIdentifier(String dbId);
 
   @DoNotChange
-  public abstract Iterable<Tuple2<MutableMetaDatabase, MetaElementState>> getModifiedDatabases();
+  public Stream<ChangedElement<MutableMetaDatabase>> streamModifiedDatabases();
 
   public abstract boolean hasChanged();
 

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/MutableMetaSnapshot.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/MutableMetaSnapshot.java
@@ -68,9 +68,6 @@ public interface MutableMetaSnapshot extends MetaSnapshot {
 
   public abstract boolean hasChanged();
 
-  @Nonnull
-  public abstract ImmutableMetaSnapshot immutableCopy();
-
   public default boolean containsMetaDatabaseByName(String dbName) {
     return getMetaDatabaseByName(dbName) != null;
   }

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/PojoChangedElement.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/PojoChangedElement.java
@@ -1,0 +1,51 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.core.transaction.metainf;
+
+import org.jooq.lambda.tuple.Tuple2;
+
+/**
+ *
+ */
+public class PojoChangedElement<E> implements ChangedElement<E> {
+
+  private final E element;
+  private final MetaElementState change;
+
+  public PojoChangedElement(E element, MetaElementState change) {
+    this.element = element;
+    this.change = change;
+  }
+
+  public PojoChangedElement(Tuple2<E, MetaElementState> tuple) {
+    this.element = tuple.v1();
+    this.change = tuple.v2();
+  }
+
+  @Override
+  public E getElement() {
+    return element;
+  }
+
+  @Override
+  public MetaElementState getChange() {
+    return change;
+  }
+
+}

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/WrapperMutableMetaDatabase.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/WrapperMutableMetaDatabase.java
@@ -19,7 +19,6 @@
 package com.torodb.core.transaction.metainf;
 
 import com.google.common.collect.Maps;
-import com.torodb.core.annotations.DoNotChange;
 import com.torodb.core.d2r.D2RLoggerFactory;
 import org.apache.logging.log4j.Logger;
 import org.jooq.lambda.tuple.Tuple2;
@@ -59,6 +58,11 @@ public class WrapperMutableMetaDatabase implements MutableMetaDatabase {
   }
 
   @Override
+  public ImmutableMetaDatabase getOrigin() {
+    return wrapped;
+  }
+
+  @Override
   public WrapperMutableMetaCollection addMetaCollection(String colName, String colId) throws
       IllegalArgumentException {
     if (getMetaCollectionByName(colName) != null) {
@@ -81,11 +85,11 @@ public class WrapperMutableMetaDatabase implements MutableMetaDatabase {
     return result;
   }
 
-  @DoNotChange
   @Override
-  public Iterable<Tuple2<MutableMetaCollection, MetaElementState>> getModifiedCollections() {
-    return Maps.filterValues(collectionsByName, tuple -> tuple.v2().hasChanged())
-        .values();
+  public Stream<ChangedElement<MutableMetaCollection>> streamModifiedCollections() {
+    return collectionsByName.values().stream()
+        .filter(tuple -> tuple.v2().hasChanged())
+        .map(PojoChangedElement::new);
   }
 
   @Override

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/WrapperMutableMetaDocPart.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/WrapperMutableMetaDocPart.java
@@ -116,9 +116,8 @@ public class WrapperMutableMetaDocPart implements MutableMetaDocPart {
   }
 
   @Override
-  @DoNotChange
-  public Iterable<ImmutableMetaField> getAddedMetaFields() {
-    return addedFields;
+  public Stream<ImmutableMetaField> streamAddedMetaFields() {
+    return addedFields.stream();
   }
 
   @Override
@@ -127,9 +126,10 @@ public class WrapperMutableMetaDocPart implements MutableMetaDocPart {
   }
 
   @Override
-  public Iterable<? extends ImmutableMetaScalar> getAddedMetaScalars() {
-    return newScalars.values();
+  public Stream<? extends ImmutableMetaScalar> streamAddedMetaScalars() {
+    return newScalars.values().stream();
   }
+
 
   @Override
   public MutableMetaDocPartIndex addMetaDocPartIndex(boolean unique) {
@@ -153,11 +153,11 @@ public class WrapperMutableMetaDocPart implements MutableMetaDocPart {
   }
 
   @Override
-  @DoNotChange
   @SuppressWarnings("checkstyle:LineLength")
-  public Iterable<Tuple2<ImmutableMetaIdentifiedDocPartIndex, MetaElementState>> getModifiedMetaDocPartIndexes() {
-    return Maps.filterValues(indexesByIdentifier, tuple -> tuple.v2().hasChanged())
-        .values();
+  public Stream<ChangedElement<ImmutableMetaIdentifiedDocPartIndex>> streamModifiedMetaDocPartIndexes() {
+    return indexesByIdentifier.values().stream()
+        .filter(tuple -> tuple.v2().hasChanged())
+        .map(PojoChangedElement::new);
   }
 
   @Override

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/WrapperMutableMetaDocPartIndex.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/WrapperMutableMetaDocPartIndex.java
@@ -19,7 +19,6 @@
 package com.torodb.core.transaction.metainf;
 
 import com.google.common.base.Preconditions;
-import com.torodb.core.annotations.DoNotChange;
 import com.torodb.core.transaction.metainf.ImmutableMetaIdentifiedDocPartIndex.Builder;
 
 import java.util.ArrayList;
@@ -29,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 /**
  *
@@ -98,9 +98,8 @@ public class WrapperMutableMetaDocPartIndex extends AbstractMetaDocPartIndex imp
   }
 
   @Override
-  @DoNotChange
-  public Iterable<ImmutableMetaDocPartIndexColumn> getAddedMetaDocPartIndexColumns() {
-    return addedColumns;
+  public Stream<? extends ImmutableMetaDocPartIndexColumn> streamAddedMetaDocPartIndexColumns() {
+    return addedColumns.stream();
   }
 
   @Override
@@ -120,6 +119,11 @@ public class WrapperMutableMetaDocPartIndex extends AbstractMetaDocPartIndex imp
   @Override
   public int size() {
     return addedColumnsByIdentifier.size();
+  }
+
+  @Override
+  public Stream<? extends MetaDocPartIndexColumn> streamColumns() {
+    return addedColumns.stream();
   }
 
   @Override

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/WrapperMutableMetaIndex.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/WrapperMutableMetaIndex.java
@@ -19,7 +19,6 @@
 package com.torodb.core.transaction.metainf;
 
 import com.torodb.core.TableRef;
-import com.torodb.core.annotations.DoNotChange;
 import com.torodb.core.transaction.metainf.ImmutableMetaIndex.Builder;
 
 import java.util.ArrayList;
@@ -38,7 +37,7 @@ public class WrapperMutableMetaIndex implements MutableMetaIndex {
 
   private final ImmutableMetaIndex wrapped;
   /**
-   * This map contains all fields contained by wrapper and all new fields
+   * This map contains all fields contained by wrapper and all new fields.
    */
   private final Map<TableRef, List<ImmutableMetaIndexField>> newFields;
   /**
@@ -82,9 +81,8 @@ public class WrapperMutableMetaIndex implements MutableMetaIndex {
   }
 
   @Override
-  @DoNotChange
-  public Iterable<ImmutableMetaIndexField> getAddedMetaIndexFields() {
-    return addedFields;
+  public Stream<? extends ImmutableMetaIndexField> streamAddedMetaIndexFields() {
+    return addedFields.stream();
   }
 
   @Override
@@ -144,7 +142,7 @@ public class WrapperMutableMetaIndex implements MutableMetaIndex {
   public ImmutableMetaIndexField getMetaIndexFieldByTableRefAndName(TableRef tableRef,
       String fieldName) {
     return newFields.computeIfAbsent(tableRef, t -> new ArrayList<>()).stream()
-        .filter(f -> f.getName().equals(fieldName))
+        .filter(f -> f.getFieldName().equals(fieldName))
         .findAny()
         .orElse(null);
   }

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/WrapperMutableMetaSnapshot.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/WrapperMutableMetaSnapshot.java
@@ -46,6 +46,10 @@ public class WrapperMutableMetaSnapshot implements MutableMetaSnapshot {
     aliveMap = Maps.filterValues(dbsByName, tuple -> tuple.v2().isAlive());
   }
 
+  public static WrapperMutableMetaSnapshot createEmpty() {
+    return new WrapperMutableMetaSnapshot(new ImmutableMetaSnapshot(Collections.emptyMap()));
+  }
+
   protected WrapperMutableMetaDatabase createMetaDatabase(ImmutableMetaDatabase immutable) {
     return new WrapperMutableMetaDatabase(immutable, this::onMetaDatabaseChange);
   }

--- a/engine/core/src/main/java/com/torodb/core/transaction/metainf/WrapperMutableMetaSnapshot.java
+++ b/engine/core/src/main/java/com/torodb/core/transaction/metainf/WrapperMutableMetaSnapshot.java
@@ -55,6 +55,11 @@ public class WrapperMutableMetaSnapshot implements MutableMetaSnapshot {
   }
 
   @Override
+  public ImmutableMetaSnapshot getOrigin() {
+    return wrapped;
+  }
+
+  @Override
   public MutableMetaDatabase addMetaDatabase(String dbName, String dbId) throws
       IllegalArgumentException {
     if (getMetaDatabaseByName(dbName) != null) {
@@ -74,9 +79,10 @@ public class WrapperMutableMetaSnapshot implements MutableMetaSnapshot {
   }
 
   @Override
-  public Iterable<Tuple2<MutableMetaDatabase, MetaElementState>> getModifiedDatabases() {
-    return Maps.filterValues(dbsByName, tuple -> tuple.v2().hasChanged())
-        .values();
+  public Stream<ChangedElement<MutableMetaDatabase>> streamModifiedDatabases() {
+    return dbsByName.values().stream()
+        .filter(tuple -> tuple.v2().hasChanged())
+        .map(PojoChangedElement::new);
   }
 
   @Override

--- a/engine/core/src/test/java/com/torodb/core/transaction/metainf/WrapperMutableMetaDatabaseTest.java
+++ b/engine/core/src/test/java/com/torodb/core/transaction/metainf/WrapperMutableMetaDatabaseTest.java
@@ -1,0 +1,61 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.core.transaction.metainf;
+
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import java.util.Collections;
+
+public class WrapperMutableMetaDatabaseTest {
+
+  @Test
+  public void indexStateOnCollectionDropAndDelete() {
+    //GIVEN
+    ImmutableMetaIndex originalIndex = new ImmutableMetaIndex("testIndex", true);
+    ImmutableMetaCollection originalCol = new ImmutableMetaCollection(
+        "testCol",
+        "testCol",
+        Collections.emptyList(),
+        Collections.singletonList(originalIndex)
+    );
+    ImmutableMetaDatabase originalDb = new ImmutableMetaDatabase(
+        "testDb",
+        "testDb",
+        Collections.singleton(originalCol)
+    );
+    WrapperMutableMetaDatabase db = new WrapperMutableMetaDatabase(originalDb, (t) -> {});
+
+    //WHEN
+    db.removeMetaCollectionByName("testCol");
+    db.addMetaCollection("testCol", "testCol");
+
+    //THEN
+    WrapperMutableMetaCollection newCol = db.getMetaCollectionByName("testCol");
+    assertThat(newCol, is(not(nullValue())));
+    WrapperMutableMetaIndex newIndex = newCol.getMetaIndexByName("testIndex");
+    assertThat(newIndex, is(nullValue()));
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/LegacySnapshotMerger.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/LegacySnapshotMerger.java
@@ -42,6 +42,7 @@ import com.torodb.core.transaction.metainf.MutableMetaDocPart;
 import com.torodb.core.transaction.metainf.MutableMetaIndex;
 import com.torodb.core.transaction.metainf.MutableMetaSnapshot;
 import com.torodb.core.transaction.metainf.UnmergeableException;
+import com.torodb.metainfo.cache.mvcc.merge.MergeStrategy;
 import com.torodb.metainfo.cache.mvcc.merge.docpartindex.DocPartIndexCtx;
 import com.torodb.metainfo.cache.mvcc.merge.docpartindex.MissedDocIndexStrategy;
 import com.torodb.metainfo.cache.mvcc.merge.docpartindex.NoDocIndexStrategy;
@@ -54,8 +55,13 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Optional;
 
 /**
+ * The old {@link SnapshotMerger} version that does not delegate on
+ * {@link MergeStrategy strategies}.
  *
+ * It is not directly used, but called by the actual merger to verify that they implement the same
+ * logic.
  */
+@Deprecated
 public class LegacySnapshotMerger {
 
   private final ImmutableMetaSnapshot oldSnapshot;

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/LegacySnapshotMerger.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/LegacySnapshotMerger.java
@@ -1,0 +1,739 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
+import com.torodb.core.transaction.metainf.ImmutableMetaDatabase;
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPartIndexColumn;
+import com.torodb.core.transaction.metainf.ImmutableMetaField;
+import com.torodb.core.transaction.metainf.ImmutableMetaIdentifiedDocPartIndex;
+import com.torodb.core.transaction.metainf.ImmutableMetaIndex;
+import com.torodb.core.transaction.metainf.ImmutableMetaIndexField;
+import com.torodb.core.transaction.metainf.ImmutableMetaScalar;
+import com.torodb.core.transaction.metainf.ImmutableMetaSnapshot;
+import com.torodb.core.transaction.metainf.MetaCollection;
+import com.torodb.core.transaction.metainf.MetaDatabase;
+import com.torodb.core.transaction.metainf.MetaDocPart;
+import com.torodb.core.transaction.metainf.MetaElementState;
+import com.torodb.core.transaction.metainf.MetaField;
+import com.torodb.core.transaction.metainf.MetaIdentifiedDocPartIndex;
+import com.torodb.core.transaction.metainf.MetaIndex;
+import com.torodb.core.transaction.metainf.MetaScalar;
+import com.torodb.core.transaction.metainf.MutableMetaCollection;
+import com.torodb.core.transaction.metainf.MutableMetaDatabase;
+import com.torodb.core.transaction.metainf.MutableMetaDocPart;
+import com.torodb.core.transaction.metainf.MutableMetaIndex;
+import com.torodb.core.transaction.metainf.MutableMetaSnapshot;
+import com.torodb.core.transaction.metainf.UnmergeableException;
+import com.torodb.metainfo.cache.mvcc.merge.docpartindex.DocPartIndexCtx;
+import com.torodb.metainfo.cache.mvcc.merge.docpartindex.MissedDocIndexStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.docpartindex.NoDocIndexStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.field.FieldContext;
+import com.torodb.metainfo.cache.mvcc.merge.field.MissingIndexStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.index.ConflictingIndexStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.index.IndexContext;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.util.Optional;
+
+/**
+ *
+ */
+public class LegacySnapshotMerger {
+
+  private final ImmutableMetaSnapshot oldSnapshot;
+  private final MutableMetaSnapshot newSnapshot;
+
+  public LegacySnapshotMerger(ImmutableMetaSnapshot oldSnapshot, MutableMetaSnapshot newSnapshot) {
+    this.oldSnapshot = oldSnapshot;
+    this.newSnapshot = newSnapshot;
+  }
+
+  public ImmutableMetaSnapshot.Builder merge() throws UnmergeableException {
+    ImmutableMetaSnapshot.Builder builder = new ImmutableMetaSnapshot.Builder(oldSnapshot);
+    newSnapshot.streamModifiedDatabases().forEach(change ->
+        mergeDb(builder, change.getElement(), change.getChange())
+    );
+    return builder;
+  }
+
+  /**
+   * Merge changes on database level.
+   *
+   * @param parentBuilder a snapshot builder that contains the state of the affected database on the
+   *                      last commited snapshot
+   * @param newDb         the database with modifications.
+   * @param newState      the new state of the given database
+   * @throws UnmergeableException if there are incompatible changes between versions
+   */
+  private void mergeDb(ImmutableMetaSnapshot.Builder parentBuilder, MutableMetaDatabase newDb,
+      MetaElementState newState) throws UnmergeableException {
+
+    //the database on the old snapshot that has the name of the modified database
+    ImmutableMetaDatabase oldByName = oldSnapshot.getMetaDatabaseByName(newDb.getName());
+    //the database on the new snapshot that has the id of the modified database
+    ImmutableMetaDatabase oldById = oldSnapshot.getMetaDatabaseByIdentifier(newDb.getIdentifier());
+
+    switch (newState) {
+      default:
+      case NOT_CHANGED:
+      case NOT_EXISTENT:
+        throw new AssertionError("A modification was expected, but the new state is " + newState);
+      case ADDED:
+      case MODIFIED: {
+        if (oldByName != oldById) {
+          //implemented by SameIdOtherName and SameNameOtherId
+          throw createUnmergeableException(newDb, oldByName, oldById);
+        }
+        if (oldByName == null && oldById == null) { //the old database didn't exist.
+          //implemented by NewDatabaseStrategy
+          parentBuilder.put(newDb.immutableCopy());
+          return;
+        }
+        assert oldByName != null;
+        assert oldById != null;
+
+        ImmutableMetaDatabase.Builder childBuilder = new ImmutableMetaDatabase.Builder(oldById);
+        newDb.streamModifiedCollections().forEach(modifiedCollection ->
+            //implemented by DatabaseModifiedChildrenStrategy
+            mergeCol(newDb, oldById, childBuilder,
+                modifiedCollection.getElement(), modifiedCollection.getChange())
+        );
+        //implemented by DatabaseModifiedChildrenStrategy
+        parentBuilder.put(childBuilder);
+        break;
+      }
+      case REMOVED: {
+        if (oldByName != oldById) {
+          //implemented by SameIdOtherName and SameNameOtherId
+          /*
+           * The backend transaction will remove by id, but it is referencing another name on the
+           * current snapshot, so the final state will be inconsistent. It is better to fail.
+           */
+          throw createUnmergeableException(newDb, oldByName, oldById);
+        }
+        if (oldByName == null && oldById == null) {
+          //implemented by NotExistentDatabaseStrategy
+          /*
+           * it has been removed on another transaction or created and removed on the current one.
+           * No change must be done
+           */
+          return;
+        }
+        assert oldByName != null;
+        assert oldById != null;
+        //implemented by DatabaseMergeStrategy
+        /*
+         * In this case, we can delegate on the backend transaction check. If it thinks everything
+         * is fine, we can remove the element. If it thinks there is an error, then we have to
+         * rollback the transaction.
+         */
+        parentBuilder.remove(oldByName);
+      }
+    }
+
+  }
+
+  /**
+   * Merge changes on collection level.
+   * 
+   * @param newStructure the new database
+   * @param oldStructure the last commited version of that database
+   * @param parentBuilder the database builder that builds the merged structure
+   * @param newCol the collection that whose modifications must be added to the builder
+   * @param newState the modification type
+   */
+  private void mergeCol(MetaDatabase newStructure, ImmutableMetaDatabase oldStructure,
+      ImmutableMetaDatabase.Builder parentBuilder,
+      MutableMetaCollection newCol, MetaElementState newState) throws UnmergeableException {
+
+    ImmutableMetaCollection oldByName = oldStructure.getMetaCollectionByName(newCol.getName());
+    ImmutableMetaCollection oldById = oldStructure
+        .getMetaCollectionByIdentifier(newCol.getIdentifier());
+
+    switch (newState) {
+      default:
+      case NOT_CHANGED:
+      case NOT_EXISTENT:
+        throw new AssertionError("A modification was expected, but the new state is " + newState);
+      case ADDED:
+      case MODIFIED: {
+        if (oldByName != oldById) {
+          //implemented by SameIdOtherName and SameNameOtherId
+          throw createUnmergeableException(oldStructure, newCol, oldByName, oldById);
+        }
+        if (oldByName == null && oldById == null) {
+          //implemented by NewCollectionStrategy
+          parentBuilder.put(newCol.immutableCopy());
+          return;
+        }
+        assert oldByName != null;
+        assert oldById != null;
+
+        ImmutableMetaCollection.Builder childBuilder = new ImmutableMetaCollection.Builder(oldById);
+        newCol.streamModifiedMetaDocParts().forEach(modifiedDocPart ->
+            mergeDocPart(newStructure, oldStructure, newCol, oldById, childBuilder, modifiedDocPart)
+        );
+        newCol.streamModifiedMetaIndexes().forEach(modifiedIndex ->
+            mergeIdx(oldStructure, newCol, oldById, childBuilder,
+                modifiedIndex.getElement(), modifiedIndex.getChange()
+            )
+        );
+        parentBuilder.put(childBuilder);
+
+        break;
+      }
+      case REMOVED: {
+        if (oldByName != oldById) {
+          //implemented by SameIdOtherName and SameNameOtherId
+          /*
+           * The backend transaction will remove by id, but it is referencing another name on the
+           * current snapshot, so the final state will be inconsistent. It is better to fail.
+           */
+          throw createUnmergeableException(oldStructure, newCol, oldByName, oldById);
+        }
+        if (oldByName == null && oldById == null) {
+          //implemented by NotExistentDatabaseStrategy
+          /*
+           * it has been removed on another transaction or created and removed on the current one.
+           * No change must be done
+           */
+          return;
+        }
+        assert oldByName != null;
+        assert oldById != null;
+        /*
+         * In this case, we can delegate on the backend transaction check. If it thinks everything
+         * is fine, we can remove the element. If it thinks there is an error, then we have to
+         * rollback the transaction.
+         */
+        parentBuilder.remove(oldByName);
+      }
+    }
+
+  }
+
+  @SuppressWarnings("checkstyle:LineLength")
+  private void mergeDocPart(MetaDatabase newDb, MetaDatabase oldDb, MutableMetaCollection newStructure,
+      ImmutableMetaCollection oldStructure,
+      ImmutableMetaCollection.Builder parentBuilder, MutableMetaDocPart changed) throws
+      UnmergeableException {
+    ImmutableMetaDocPart oldByRef = oldStructure.getMetaDocPartByTableRef(changed.getTableRef());
+    ImmutableMetaDocPart oldById = oldStructure.getMetaDocPartByIdentifier(changed.getIdentifier());
+
+    if (oldByRef != oldById) {
+      throw createUnmergeableException(oldDb, oldStructure, changed, oldByRef, oldById);
+    }
+    if (oldByRef == null && oldById == null) {
+      //implemented by NewDocPartStrategy
+      parentBuilder.put(changed.immutableCopy());
+      return;
+    }
+    assert oldByRef != null;
+    assert oldById != null;
+
+    ImmutableMetaDocPart.Builder childBuilder = new ImmutableMetaDocPart.Builder(oldById);
+
+    changed.streamAddedMetaFields().forEach(addedMetaField ->
+        //Implemented by DocPartRecurrentStrategy
+        mergeField(oldDb, newStructure, oldStructure, changed, oldById, childBuilder,
+            addedMetaField)
+    );
+    changed.streamAddedMetaScalars().forEach(addedMetaScalar ->
+        //Implemented by DocPartRecurrentStrategy
+        mergeScalar(oldDb, oldStructure, oldById, childBuilder, addedMetaScalar)
+    );
+    changed.streamModifiedMetaDocPartIndexes().forEach(addedMetaDocPartIndex ->
+        //Implemented by DocPartRecurrentStrategy
+        mergeDocPartIdx(oldDb, newStructure, oldStructure, changed, oldById, childBuilder,
+            addedMetaDocPartIndex.getElement(), addedMetaDocPartIndex.getChange())
+    );
+
+    parentBuilder.put(childBuilder);
+
+  }
+
+  private void mergeField(MetaDatabase oldDb, MutableMetaCollection newCol, 
+      ImmutableMetaCollection oldCol,
+      MutableMetaDocPart newStructure, ImmutableMetaDocPart oldStructure,
+      ImmutableMetaDocPart.Builder parentBuilder, ImmutableMetaField changed) throws
+      UnmergeableException {
+    ImmutableMetaField byNameAndType = oldStructure.getMetaFieldByNameAndType(changed.getName(),
+        changed.getType());
+    ImmutableMetaField byId = oldStructure.getMetaFieldByIdentifier(changed.getIdentifier());
+
+    if (byNameAndType != byId) {
+      throw createUnmergeableException(oldDb, oldCol, oldStructure, changed, byNameAndType, byId);
+    }
+
+    if (byNameAndType == null && byId == null) {
+      FieldContext ctx = new FieldContext(oldStructure, changed, newStructure, oldCol,
+          newCol);
+
+      Optional<? extends MetaIndex> oldMissedIndex = MissingIndexStrategy.getAnyMissedIndex(ctx);
+
+      if (oldMissedIndex.isPresent()) {
+        throw createUnmergeableExceptionForMissing(oldDb, oldCol, oldStructure, changed,
+            oldMissedIndex.get());
+      }
+
+      //implemented by NewFieldStrategy
+      parentBuilder.put(changed);
+    }
+  }
+
+  private void mergeScalar(MetaDatabase db, MetaCollection col, ImmutableMetaDocPart oldStructure,
+      ImmutableMetaDocPart.Builder parentBuilder, ImmutableMetaScalar changed) {
+    MetaScalar byId = oldStructure.getScalar(changed.getIdentifier());
+    MetaScalar byType = oldStructure.getScalar(changed.getType());
+
+    if (byType != byId) {
+      throw createUnmergeableException(db, col, oldStructure, changed, byType, byId);
+    }
+    if (byType == null && byId == null) {
+      //implemented by NewFieldStrategy
+      parentBuilder.put(changed);
+    }
+  }
+
+  @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
+  private void mergeDocPartIdx(MetaDatabase oldDb, MutableMetaCollection newCol,
+      ImmutableMetaCollection oldCol, MutableMetaDocPart newStructure, 
+      ImmutableMetaDocPart oldStructure, ImmutableMetaDocPart.Builder parentBuilder,
+      ImmutableMetaIdentifiedDocPartIndex changed, MetaElementState newState)
+      throws UnmergeableException {
+    ImmutableMetaIdentifiedDocPartIndex byId = oldStructure.getMetaDocPartIndexByIdentifier(changed
+        .getIdentifier());
+
+    switch (newState) {
+      default:
+      case NOT_CHANGED:
+      case NOT_EXISTENT:
+        throw new AssertionError("A modification was expected, but the new state is " + newState);
+      case ADDED:
+      case MODIFIED: {
+        DocPartIndexCtx ctx = new DocPartIndexCtx(
+            oldStructure,
+            changed,
+            MetaElementState.ADDED,
+            newStructure,
+            oldCol,
+            newCol
+        );
+        Optional<? extends MetaIndex> anyRelatedIndex = NoDocIndexStrategy.getAnyRelatedIndex(ctx);
+
+        if (!anyRelatedIndex.isPresent()) {
+          //Implemented by NoDocIndexStrategy
+          throw createUnmergeableExceptionForOrphan(oldDb, oldCol, oldStructure, changed);
+        }
+
+        if (byId == null) {
+          //implemented by NewDocPartIndexStrategy
+          parentBuilder.put(changed);
+          return;
+        }
+        assert byId != null;
+
+        ImmutableMetaIdentifiedDocPartIndex.Builder childBuilder =
+            new ImmutableMetaIdentifiedDocPartIndex.Builder(byId);
+
+        //implemented by DocPartIndexChildrenStrategy
+        changed.streamColumns().forEach(indexColumn ->
+            mergeIndexColumn(oldDb, oldCol, oldStructure, byId, childBuilder,
+                indexColumn.immutableCopy())
+        );
+
+        //implemented by DocPartIndexChildrenStrategy
+        parentBuilder.put(childBuilder);
+
+        break;
+      }
+      case REMOVED: {
+        DocPartIndexCtx ctx = new DocPartIndexCtx(oldStructure, changed, MetaElementState.ADDED,
+            newStructure, oldCol, newCol);
+        Optional<? extends MetaIndex> oldMissedIndex
+            = MissedDocIndexStrategy.getAnyMissedIndex(ctx);
+
+        if (oldMissedIndex.isPresent()) {
+          //implemented by MissedDocIndexStrategy
+          throw createUnmergeableExceptionForMissing(oldDb, oldCol, oldStructure, changed,
+              oldMissedIndex.get());
+        }
+
+        ImmutableMetaIdentifiedDocPartIndex bySameColumns = oldStructure.streamIndexes()
+            .filter(oldDocPartIndex -> oldDocPartIndex.hasSameColumns(changed))
+            .findAny()
+            .orElse(null);
+
+        if (byId == null || bySameColumns == null) {
+          //implemented by NotExistentDocPartIndexStrategy
+          /*
+           * it has been removed on another transaction or created and removed on the current one.
+           * No change must be done
+           */
+          return;
+        }
+        assert byId != null;
+        assert bySameColumns != null;
+        /*
+         * In this case, we can delegate on the backend transaction check. If it thinks everything
+         * is fine, we can remove the element. If it thinks there is an error, then we have to
+         * rollback the transaction.
+         */
+        parentBuilder.remove(byId);
+      }
+    }
+  }
+
+  private void mergeIndexColumn(MetaDatabase db, MetaCollection col, MetaDocPart docPart,
+      ImmutableMetaIdentifiedDocPartIndex oldStructure,
+      ImmutableMetaIdentifiedDocPartIndex.Builder parentBuilder,
+      ImmutableMetaDocPartIndexColumn changed) throws UnmergeableException {
+    ImmutableMetaDocPartIndexColumn byIdentifier = oldStructure
+        .getMetaDocPartIndexColumnByIdentifier(changed.getIdentifier());
+    ImmutableMetaDocPartIndexColumn byPosition = oldStructure.getMetaDocPartIndexColumnByPosition(
+        changed.getPosition());
+
+    if (byIdentifier != byPosition) {
+      //implemented by SamePositionOtherIdNameStrategy and SameIdOtherPositionNameStrategy
+      throw createUnmergeableException(db, col, docPart, oldStructure, changed, byIdentifier,
+          byPosition);
+    }
+    if (byIdentifier == null && byPosition == null) {
+      //implemented by NewIndexColumnStrategy
+      parentBuilder.add(changed);
+    }
+  }
+
+  @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
+  private void mergeIdx(MetaDatabase oldDb, MutableMetaCollection newStructure,
+      ImmutableMetaCollection oldStructure,
+      ImmutableMetaCollection.Builder parentBuilder, MutableMetaIndex changed,
+      MetaElementState newState) throws UnmergeableException {
+    ImmutableMetaIndex byName = oldStructure.getMetaIndexByName(changed.getName());
+
+    switch (newState) {
+      default:
+      case NOT_CHANGED:
+      case NOT_EXISTENT:
+        throw new AssertionError("A modification was expected, but the new state is " + newState);
+      case ADDED:
+      case MODIFIED: {
+        IndexContext ctx = new IndexContext(oldStructure, changed, newState, newStructure);
+        Optional<? extends MetaIndex> anyConflictingIndex = ConflictingIndexStrategy
+            .getAnyConflictingIndex(ctx);
+
+        if (anyConflictingIndex.isPresent()) {
+          //implemented by ConflictingIndexStrategy
+          throw createUnmergeableException(oldDb, oldStructure, changed, anyConflictingIndex.get());
+        }
+
+        Optional<? extends MetaDocPart> anyDocPartWithMissingDocPartIndex =
+            newStructure.getAnyDocPartWithMissedDocPartIndex(oldStructure, changed);
+
+        if (anyDocPartWithMissingDocPartIndex.isPresent()) {
+          //implemented by AnyDocPartWithMissedDocPartIndexStrategy
+          throw createUnmergeableExceptionForMissing(oldDb, oldStructure, changed,
+              anyDocPartWithMissingDocPartIndex.get());
+        }
+
+        if (byName == null) {
+          //implemented by NewIndexStrategy
+          parentBuilder.put(changed.immutableCopy());
+          return;
+        }
+        assert byName != null;
+
+        
+        ImmutableMetaIndex.Builder childBuilder = new ImmutableMetaIndex.Builder(byName);
+ 
+        //implemented by IndexChildrenStrategy
+        changed.streamAddedMetaIndexFields().forEach(addedMetaIndexField ->
+            mergeIndexField(oldDb, oldStructure, byName, childBuilder, addedMetaIndexField)
+        );
+
+        parentBuilder.put(childBuilder);
+
+        break;
+      }
+      case REMOVED: {
+        Optional<? extends MetaIdentifiedDocPartIndex> orphanDocPartIndex = newStructure
+            .getAnyOrphanDocPartIndex(oldStructure, changed);
+
+        if (orphanDocPartIndex.isPresent()) {
+          //implemented by OrphanDocPartIndexStrategy
+          throw createUnmergeableExceptionForOrphan(oldDb, oldStructure, changed, orphanDocPartIndex
+              .get());
+        }
+
+        if (byName == null) {
+          //implemented by NotExistentIndexStrategy
+          /*
+           * it has been removed on another transaction or created and removed on the current one.
+           * No change must be done
+           */
+          return;
+        }
+        assert byName != null;
+
+        /*
+         * In this case, we can delegate on the backend transaction check. If it thinks everything
+         * is fine, we can remove the element. If it thinks there is an error, then we have to
+         * rollback the transaction.
+         */
+        parentBuilder.remove(byName);
+      }
+    }
+  }
+
+  private void mergeIndexField(MetaDatabase db, MetaCollection col, ImmutableMetaIndex oldStructure,
+      ImmutableMetaIndex.Builder parentBuilder, ImmutableMetaIndexField changed) throws
+      UnmergeableException {
+    ImmutableMetaIndexField byTableRefAndName = oldStructure.getMetaIndexFieldByTableRefAndName(
+        changed.getTableRef(), changed.getFieldName());
+    ImmutableMetaIndexField byPosition = oldStructure.getMetaIndexFieldByPosition(changed
+        .getPosition());
+
+    if (byTableRefAndName != byPosition) {
+      //implemented by samePosition*Strategy and sameRefAndNameOtherPositionStrategy
+      throw createUnmergeableException(db, col, oldStructure, changed, byTableRefAndName,
+          byPosition);
+    }
+    if (byTableRefAndName == null && byPosition == null) {
+      //implemented by NewIndexFieldStrategy
+      parentBuilder.add(changed);
+    }
+  }
+
+  private UnmergeableException createUnmergeableException(
+      MetaDatabase newDb, ImmutableMetaDatabase byName, ImmutableMetaDatabase byId) {
+
+    //implemented by SameIdOtherName and SameNameOtherId
+    if (byName != null) {
+      throw new UnmergeableException(oldSnapshot, newSnapshot,
+          "There is a previous database whose name is " + byName.getName()
+          + " that has a different id. The previous element id is "
+          + byName.getIdentifier() + " and the new one is " + newDb.getIdentifier());
+    } else {
+      assert byId != null;
+      throw new UnmergeableException(oldSnapshot, newSnapshot,
+          "There is a previous database whose id is " + byId.getIdentifier()
+          + " that has a different name. The previous element name is "
+          + byId.getName() + " and the new one is " + newDb.getName());
+    }
+  }
+
+  private UnmergeableException createUnmergeableException(
+      MetaDatabase db,
+      MutableMetaCollection newCol, ImmutableMetaCollection byName, ImmutableMetaCollection byId) {
+
+    if (byName != null) {
+      throw new UnmergeableException(oldSnapshot, newSnapshot,
+          "There is a previous collection on " + db + " whose name is "
+          + byName.getName() + " that has a different id. The previous "
+          + "element id is " + byName.getIdentifier() + " and the new one is "
+          + newCol.getIdentifier());
+    } else {
+      assert byId != null;
+      throw new UnmergeableException(oldSnapshot, newSnapshot,
+          "There is a previous collection on " + db + " whose id is "
+          + byId.getIdentifier() + " that has a different name. The previous "
+          + "element name is " + byId.getName() + " and the new one is "
+          + newCol.getIdentifier());
+    }
+  }
+
+  private UnmergeableException createUnmergeableException(
+      MetaDatabase db,
+      MetaCollection col, MutableMetaDocPart changed, ImmutableMetaDocPart byRef,
+      ImmutableMetaDocPart byId) {
+    //implemented by SameIdOtherRef and SameRefOtherId
+
+    if (byRef != null) {
+      throw new UnmergeableException(oldSnapshot, newSnapshot,
+          "There is a previous doc part on " + db + "." + col + " whose ref is "
+          + byRef.getTableRef() + " that has a different id. The previous "
+          + "element id is " + byRef.getIdentifier() + " and the new one is "
+          + changed.getIdentifier());
+    } else {
+      assert byId != null;
+      throw new UnmergeableException(oldSnapshot, newSnapshot,
+          "There is a previous doc part on " + db + "." + col + " whose id is "
+          + byId.getIdentifier() + " that has a different ref. The previous "
+          + "element ref is " + byId.getTableRef() + " and the new one is "
+          + changed.getTableRef());
+    }
+  }
+
+  private UnmergeableException createUnmergeableException(
+      MetaDatabase db, MetaCollection col, MetaDocPart docPart, ImmutableMetaField changed,
+      ImmutableMetaField byNameAndType, ImmutableMetaField byId) {
+    //implemented by SameIdOtherRef and SameRefOtherId
+    if (byNameAndType != null) {
+      throw new UnmergeableException(oldSnapshot, newSnapshot,
+          "There is a previous field on doc part " + db + "." + col + "." + docPart + " whose "
+          + "name is " + byNameAndType.getName() + " and type is "
+          + byNameAndType.getType() + " that has a different id. The previous "
+          + "element id is " + byNameAndType.getIdentifier() + " and the new "
+          + "one is " + changed.getIdentifier());
+    } else {
+      assert byId != null;
+      throw new UnmergeableException(oldSnapshot, newSnapshot,
+          "There is a previous field on doc part " + db.getIdentifier() + "." + col.getIdentifier()
+          + "." + docPart.getIdentifier() + " whose id is " + byId.getIdentifier()
+          + " that has a different name or "
+          + "type. The previous element name is " + byId.getName() + " and its "
+          + "type is " + byId.getType() + ". The name of the new one is "
+          + changed.getName() + " and its type is " + changed.getType());
+    }
+  }
+
+  private UnmergeableException createUnmergeableException(
+      MetaDatabase db, MetaCollection col, MetaDocPart docPart, ImmutableMetaScalar changed,
+      MetaScalar byType, MetaScalar byId) {
+    //implemented by SameIdOtherRef and SameRefOtherId
+    if (byType != null) {
+      throw new UnmergeableException(oldSnapshot, newSnapshot,
+          "There is a previous meta scalar on " + db.getIdentifier() + "."
+          + col.getIdentifier() + "." + docPart.getIdentifier() + " whose "
+          + "type is " + changed.getType() + " but its identifier is "
+          + byType.getIdentifier() + ". The identifier of the new one is "
+          + changed.getIdentifier()
+      );
+    } else {
+      assert byId != null;
+      throw new UnmergeableException(oldSnapshot, newSnapshot,
+          "There is a previous meta scalar on " + db.getIdentifier() + "."
+          + col.getIdentifier() + "." + docPart.getIdentifier() + " whose "
+          + "identifier is " + changed.getIdentifier() + " but its type is "
+          + byId.getType() + ". The type of the new one is " + changed.getType()
+      );
+    }
+  }
+
+  private UnmergeableException createUnmergeableException(
+      MetaDatabase db, MetaCollection col, MetaDocPart docPart, MetaIdentifiedDocPartIndex index,
+      ImmutableMetaDocPartIndexColumn changed,
+      ImmutableMetaDocPartIndexColumn byIdentifier, ImmutableMetaDocPartIndexColumn byPosition) {
+    if (byIdentifier != null) {
+      throw new UnmergeableException(oldSnapshot, newSnapshot,
+          "There is a previous field on doc part index " + db.getIdentifier() + "." + col
+          .getIdentifier() + "." + docPart.getIdentifier() + "." + index.getIdentifier() + " whose "
+          + "identifier is " + byIdentifier.getIdentifier()
+          + " that has a different position. The previous "
+          + "element position is " + byIdentifier.getPosition() + " and the new "
+          + "one is " + changed.getPosition());
+    } else {
+      assert byPosition != null;
+      throw new UnmergeableException(oldSnapshot, newSnapshot,
+          "There is a previous field on doc part index " + db.getIdentifier() + "." + col
+          .getIdentifier()
+          + "." + docPart.getIdentifier() + "." + index.getIdentifier() + " whose position is "
+          + byPosition.getPosition() + " that has a different name or "
+          + "type. The previous element identifier is " + byPosition.getIdentifier()
+          + ". The name of the new one is " + changed.getIdentifier());
+    }
+  }
+
+  private UnmergeableException createUnmergeableException(
+      MetaDatabase db, MetaCollection col, MetaIndex index, ImmutableMetaIndexField changed,
+      ImmutableMetaIndexField byTableRefAndName, ImmutableMetaIndexField byPosition) {
+    if (byTableRefAndName != null) {
+      throw new UnmergeableException(oldSnapshot, newSnapshot,
+          "There is a previous field on index " + db + "." + col + "." + index + " whose "
+          + "tableRef is " + byTableRefAndName.getTableRef() + " and name is "
+          + byTableRefAndName.getFieldName() + " that has a different position. The previous "
+          + "element position is " + byTableRefAndName.getPosition() + " and the new "
+          + "one is " + changed.getPosition());
+    } else {
+      assert byPosition != null;
+      throw new UnmergeableException(oldSnapshot, newSnapshot,
+          "There is a previous field on index " + db + "." + col
+          + "." + index + " whose position is " + byPosition.getPosition()
+          + " that has a different tableRef or "
+          + "name. The previous element tableRef is " + byPosition.getTableRef() + " and its "
+          + "name is " + byPosition.getFieldName() + ". The tableRef of the new one is "
+          + changed.getTableRef() + " and its name is " + changed.getFieldName());
+    }
+  }
+
+  private UnmergeableException createUnmergeableException(
+      MetaDatabase db,
+      MetaCollection col, MutableMetaIndex changed, MetaIndex oldIndex) {
+    throw new UnmergeableException(oldSnapshot, newSnapshot,
+        "There is a previous index on " + db + "." + col + "." + oldIndex
+        + " that conflict with new index "
+        + changed);
+  }
+
+  private UnmergeableException createUnmergeableExceptionForMissing(
+      MetaDatabase db,
+      MetaCollection col, MetaDocPart docPart, MetaField changed, MetaIndex oldMissedIndex) {
+    throw new UnmergeableException(oldSnapshot, newSnapshot,
+        "There is a previous index on " + db + "." + col
+        + " whose name is " + oldMissedIndex.getName()
+        + " associated with new doc part field " + docPart + "."
+        + changed + " and the corresponding doc part index has not been created.");
+  }
+
+  private UnmergeableException createUnmergeableExceptionForMissing(
+      MetaDatabase db, MetaCollection col, MetaDocPart docPart, MetaIdentifiedDocPartIndex changed,
+      MetaIndex oldMissedIndex) {
+    throw new UnmergeableException(oldSnapshot, newSnapshot,
+        "There is a previous doc part index " + db + "." + col + "." + docPart + "."
+        + oldMissedIndex
+        + " that is compatible with the removed doc part index "
+        + db.getIdentifier() + "." + col.getIdentifier() + "." + docPart.getIdentifier() + "."
+        + changed.getIdentifier());
+  }
+
+  private UnmergeableException createUnmergeableExceptionForMissing(
+      MetaDatabase db,
+      MetaCollection col, MutableMetaIndex changed, MetaDocPart oldDocPartForMissedIndex) {
+    throw new UnmergeableException(oldSnapshot, newSnapshot,
+        "There should be a doc part index on " + db + "." + col + "." + oldDocPartForMissedIndex
+        + " associated only with new index "
+        + changed + " that has not been created.");
+  }
+
+  private UnmergeableException createUnmergeableExceptionForOrphan(
+      MetaDatabase db,
+      MetaCollection col,
+      MetaDocPart docPart,
+      MetaIdentifiedDocPartIndex changed) {
+    throw new UnmergeableException(oldSnapshot, newSnapshot,
+        "There is a new doc part index " + db.getIdentifier() + "." + col.getIdentifier() + "."
+        + docPart.getIdentifier() + "." + changed.getIdentifier()
+        + " that has no index associated");
+  }
+
+  private UnmergeableException createUnmergeableExceptionForOrphan(
+      MetaDatabase db,
+      MetaCollection col, 
+      MutableMetaIndex changed,
+      MetaIdentifiedDocPartIndex oldOrphanDocPartIndex) {
+    throw new UnmergeableException(oldSnapshot, newSnapshot,
+        "There is a previous doc part index on " + db.getIdentifier() + "." + oldOrphanDocPartIndex
+        .getIdentifier()
+        + " associated only with removed index "
+        + changed + " that has not been deleted.");
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/SnapshotMerger.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/SnapshotMerger.java
@@ -24,15 +24,17 @@ import com.torodb.core.transaction.metainf.ImmutableMetaSnapshot;
 import com.torodb.core.transaction.metainf.MutableMetaDatabase;
 import com.torodb.core.transaction.metainf.MutableMetaSnapshot;
 import com.torodb.core.transaction.metainf.UnmergeableException;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
 import com.torodb.metainfo.cache.mvcc.merge.db.DatabaseMergeStrategy;
 import com.torodb.metainfo.cache.mvcc.merge.db.DbContext;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ParentDescriptionFun;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Optional;
 
 /**
- *
+ * The class used to merge the last commited {@link ImmutableMetaSnapshot} with a uncommited
+ * {@link MutableMetaSnapshot}.
  */
 public class SnapshotMerger {
 
@@ -46,6 +48,13 @@ public class SnapshotMerger {
     this.newSnapshot = newSnapshot;
   }
 
+  /**
+   * Merge the uncommited snapshot into the commited one.
+   *
+   * @return a {@link ImmutableMetaSnapshot.Builder} that can be used to create the merged snapshot.
+   * @throws UnmergeableException if there is an incompatibility that makes impossible to merge the
+   *                              uncommited into the commited snapshot
+   */
   public ImmutableMetaSnapshot.Builder merge() throws UnmergeableException {
 
     ImmutableMetaSnapshot.Builder builder = new ImmutableMetaSnapshot.Builder(oldSnapshot);
@@ -75,7 +84,7 @@ public class SnapshotMerger {
   }
 
   private String getErrorMessage(ExecutionResult<ImmutableMetaSnapshot> result) {
-    ExecutionResult.ParentDescriptionFun<ImmutableMetaSnapshot> snapshotDescFun = (snapshot) -> "";
+    ParentDescriptionFun<ImmutableMetaSnapshot> snapshotDescFun = (snapshot) -> "";
     return result.getErrorMessageFactory()
         .map(errFactory -> errFactory.apply(snapshotDescFun))
         .orElse("unknown");

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/SnapshotMerger.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/SnapshotMerger.java
@@ -18,34 +18,17 @@
 
 package com.torodb.metainfo.cache.mvcc;
 
-import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
-import com.torodb.core.transaction.metainf.ImmutableMetaDatabase;
-import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
-import com.torodb.core.transaction.metainf.ImmutableMetaDocPartIndexColumn;
-import com.torodb.core.transaction.metainf.ImmutableMetaField;
-import com.torodb.core.transaction.metainf.ImmutableMetaIdentifiedDocPartIndex;
-import com.torodb.core.transaction.metainf.ImmutableMetaIndex;
-import com.torodb.core.transaction.metainf.ImmutableMetaIndexField;
-import com.torodb.core.transaction.metainf.ImmutableMetaScalar;
+import com.torodb.core.d2r.D2RLoggerFactory;
+import com.torodb.core.transaction.metainf.ChangedElement;
 import com.torodb.core.transaction.metainf.ImmutableMetaSnapshot;
-import com.torodb.core.transaction.metainf.MetaCollection;
-import com.torodb.core.transaction.metainf.MetaDatabase;
-import com.torodb.core.transaction.metainf.MetaDocPart;
-import com.torodb.core.transaction.metainf.MetaElementState;
-import com.torodb.core.transaction.metainf.MetaField;
-import com.torodb.core.transaction.metainf.MetaIdentifiedDocPartIndex;
-import com.torodb.core.transaction.metainf.MetaIndex;
-import com.torodb.core.transaction.metainf.MetaScalar;
-import com.torodb.core.transaction.metainf.MutableMetaCollection;
 import com.torodb.core.transaction.metainf.MutableMetaDatabase;
-import com.torodb.core.transaction.metainf.MutableMetaDocPart;
-import com.torodb.core.transaction.metainf.MutableMetaIndex;
 import com.torodb.core.transaction.metainf.MutableMetaSnapshot;
 import com.torodb.core.transaction.metainf.UnmergeableException;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.jooq.lambda.tuple.Tuple2;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.db.DatabaseMergeStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.db.DbContext;
+import org.apache.logging.log4j.Logger;
 
-import java.util.Iterator;
 import java.util.Optional;
 
 /**
@@ -53,6 +36,8 @@ import java.util.Optional;
  */
 public class SnapshotMerger {
 
+  private static final Logger LOGGER = D2RLoggerFactory.get(SnapshotMerger.class);
+  private static final DatabaseMergeStrategy DB_MERGE_STRATEGY = new DatabaseMergeStrategy();
   private final ImmutableMetaSnapshot oldSnapshot;
   private final MutableMetaSnapshot newSnapshot;
 
@@ -62,599 +47,71 @@ public class SnapshotMerger {
   }
 
   public ImmutableMetaSnapshot.Builder merge() throws UnmergeableException {
+
     ImmutableMetaSnapshot.Builder builder = new ImmutableMetaSnapshot.Builder(oldSnapshot);
-    Iterable<Tuple2<MutableMetaDatabase, MetaElementState>> changes = newSnapshot
-        .getModifiedDatabases();
-    for (Tuple2<MutableMetaDatabase, MetaElementState> change : changes) {
-      merge(builder, change.v1(), change.v2());
+
+    ExecutionResult<ImmutableMetaSnapshot> result = newSnapshot.streamModifiedDatabases()
+        .map(change -> mergeDb(change, builder))
+        .filter(dbResult -> !dbResult.isSuccess())
+        .findAny()
+        .orElse(ExecutionResult.success());
+
+    checkLegacy(result, builder)
+        .ifPresent(diff -> LOGGER.warn(diff));
+
+    if (!result.isSuccess()) {
+      throw new UnmergeableException(oldSnapshot, newSnapshot, getErrorMessage(result));
     }
+
     return builder;
   }
 
-  private void merge(ImmutableMetaSnapshot.Builder parentBuilder, MutableMetaDatabase newDb,
-      MetaElementState newState) throws UnmergeableException {
+  private ExecutionResult<ImmutableMetaSnapshot> mergeDb(
+      ChangedElement<MutableMetaDatabase> change, ImmutableMetaSnapshot.Builder parentBuilder) {
 
-    ImmutableMetaDatabase byName = oldSnapshot.getMetaDatabaseByName(newDb.getName());
-    ImmutableMetaDatabase byId = oldSnapshot.getMetaDatabaseByIdentifier(newDb.getIdentifier());
+    DbContext ctx = new DbContext(oldSnapshot, change);
 
-    switch (newState) {
-      default:
-      case NOT_CHANGED:
-      case NOT_EXISTENT:
-        throw new AssertionError("A modification was expected, but the new state is " + newState);
-      case ADDED:
-      case MODIFIED: {
-        if (byName != byId) {
-          throw createUnmergeableException(newDb, byName, byId);
-        }
-        if (byName == null && byId == null) {
-          parentBuilder.put(newDb.immutableCopy());
-          return;
-        }
-        assert byName != null;
-        assert byId != null;
-
-        ImmutableMetaDatabase.Builder childBuilder = new ImmutableMetaDatabase.Builder(byId);
-        for (Tuple2<MutableMetaCollection, MetaElementState> modifiedCollection : newDb
-            .getModifiedCollections()) {
-          merge(newDb, byId, childBuilder, modifiedCollection.v1(), modifiedCollection.v2());
-        }
-        parentBuilder.put(childBuilder);
-        break;
-      }
-      case REMOVED: {
-        if (byName != byId) {
-          /*
-           * The backend transaction will remove by id, but it is referencing another name on the
-           * current snapshot, so the final state will be inconsistent. It is better to fail.
-           */
-          throw createUnmergeableException(newDb, byName, byId);
-        }
-        if (byName == null && byId == null) {
-          /*
-           * it has been removed on another transaction or created and removed on the current one.
-           * No change must be done
-           */
-          return;
-        }
-        assert byName != null;
-        assert byId != null;
-        /*
-         * In this case, we can delegate on the backend transaction check. If it thinks everything
-         * is fine, we can remove the element. If it thinks there is an error, then we have to
-         * rollback the transaction.
-         */
-        parentBuilder.remove(byName);
-      }
-    }
-
+    return DB_MERGE_STRATEGY.execute(ctx, parentBuilder);
   }
 
-  private void merge(MetaDatabase newStructure, ImmutableMetaDatabase oldStructure,
-      ImmutableMetaDatabase.Builder parentBuilder,
-      MutableMetaCollection newCol, MetaElementState newState) throws UnmergeableException {
-
-    ImmutableMetaCollection byName = oldStructure.getMetaCollectionByName(newCol.getName());
-    ImmutableMetaCollection byId = oldStructure
-        .getMetaCollectionByIdentifier(newCol.getIdentifier());
-
-    switch (newState) {
-      default:
-      case NOT_CHANGED:
-      case NOT_EXISTENT:
-        throw new AssertionError("A modification was expected, but the new state is " + newState);
-      case ADDED:
-      case MODIFIED: {
-        if (byName != byId) {
-          throw createUnmergeableException(oldStructure, newCol, byName, byId);
-        }
-        if (byName == null && byId == null) {
-          parentBuilder.put(newCol.immutableCopy());
-          return;
-        }
-        assert byName != null;
-        assert byId != null;
-
-        ImmutableMetaCollection.Builder childBuilder = new ImmutableMetaCollection.Builder(byId);
-        for (MutableMetaDocPart modifiedDocPart : newCol.getModifiedMetaDocParts()) {
-          merge(newStructure, oldStructure, newCol, byId, childBuilder, modifiedDocPart);
-        }
-        for (Tuple2<MutableMetaIndex, MetaElementState> modifiedIndex : newCol
-            .getModifiedMetaIndexes()) {
-          merge(oldStructure, newCol, byId, childBuilder, modifiedIndex.v1(), modifiedIndex.v2());
-        }
-        parentBuilder.put(childBuilder);
-
-        break;
-      }
-      case REMOVED: {
-        if (byName != byId) {
-          /*
-           * The backend transaction will remove by id, but it is referencing another name on the
-           * current snapshot, so the final state will be inconsistent. It is better to fail.
-           */
-          throw createUnmergeableException(oldStructure, newCol, byName, byId);
-        }
-        if (byName == null && byId == null) {
-          /*
-           * it has been removed on another transaction or created and removed on the current one.
-           * No change must be done
-           */
-          return;
-        }
-        assert byName != null;
-        assert byId != null;
-        /*
-         * In this case, we can delegate on the backend transaction check. If it thinks everything
-         * is fine, we can remove the element. If it thinks there is an error, then we have to
-         * rollback the transaction.
-         */
-        parentBuilder.remove(byName);
-      }
-    }
-
+  private String getErrorMessage(ExecutionResult<ImmutableMetaSnapshot> result) {
+    ExecutionResult.ParentDescriptionFun<ImmutableMetaSnapshot> snapshotDescFun = (snapshot) -> "";
+    return result.getErrorMessageFactory()
+        .map(errFactory -> errFactory.apply(snapshotDescFun))
+        .orElse("unknown");
   }
 
-  @SuppressWarnings("checkstyle:LineLength")
-  private void merge(MetaDatabase newDb, MetaDatabase oldDb, MutableMetaCollection newStructure,
-      ImmutableMetaCollection oldStructure,
-      ImmutableMetaCollection.Builder parentBuilder, MutableMetaDocPart changed) throws
-      UnmergeableException {
-    ImmutableMetaDocPart byRef = oldStructure.getMetaDocPartByTableRef(changed.getTableRef());
-    ImmutableMetaDocPart byId = oldStructure.getMetaDocPartByIdentifier(changed.getIdentifier());
+  private Optional<String> checkLegacy(
+      ExecutionResult<ImmutableMetaSnapshot> newResult,
+      ImmutableMetaSnapshot.Builder builder) {
 
-    if (byRef != byId) {
-      throw createUnmergeableException(oldDb, oldStructure, changed, byRef, byId);
-    }
-    if (byRef == null && byId == null) {
-      parentBuilder.put(changed.immutableCopy());
-      return;
-    }
-    assert byRef != null;
-    assert byId != null;
-
-    ImmutableMetaDocPart.Builder childBuilder = new ImmutableMetaDocPart.Builder(byId);
-
-    for (ImmutableMetaField addedMetaField : changed.getAddedMetaFields()) {
-      merge(oldDb, newStructure, oldStructure, changed, byId, childBuilder, addedMetaField);
-    }
-    for (ImmutableMetaScalar addedMetaScalar : changed.getAddedMetaScalars()) {
-      merge(oldDb, oldStructure, byId, childBuilder, addedMetaScalar);
-    }
-    for (Tuple2<ImmutableMetaIdentifiedDocPartIndex, MetaElementState> addedMetaDocPartIndex : changed.getModifiedMetaDocPartIndexes()) {
-      merge(oldDb, newStructure, oldStructure, changed, byId, childBuilder, addedMetaDocPartIndex
-          .v1(), addedMetaDocPartIndex.v2());
+    UnmergeableException error;
+    try {
+      legacyMerge();
+      error = null;
+    } catch (UnmergeableException ex) {
+      error = ex;
     }
 
-    parentBuilder.put(childBuilder);
-
+    if (error != null && newResult.isSuccess()) {
+      return Optional.of("Legacy merger found and error not reported by the strategy merger. "
+          + "Error found: " + error.getMessage());
+    }
+    if (error == null && !newResult.isSuccess()) {
+      return Optional.of(
+          "Strategy merger found and error not reported by the legacy merger. "
+          + "Error found: " + getErrorMessage(newResult));
+    }
+    if (error != null && !newResult.isSuccess()) {
+      return Optional.empty();
+    }
+    //To be totally correct, we should check that generated immutables are the same
+    return Optional.empty();
   }
 
-  private void merge(MetaDatabase oldDb, MutableMetaCollection newCol, MetaCollection oldCol,
-      MutableMetaDocPart newStructure, ImmutableMetaDocPart oldStructure,
-      ImmutableMetaDocPart.Builder parentBuilder, ImmutableMetaField changed) throws
-      UnmergeableException {
-    ImmutableMetaField byNameAndType = oldStructure.getMetaFieldByNameAndType(changed.getName(),
-        changed.getType());
-    ImmutableMetaField byId = oldStructure.getMetaFieldByIdentifier(changed.getIdentifier());
+  private ImmutableMetaSnapshot legacyMerge() throws UnmergeableException {
+    LegacySnapshotMerger legacyMerger = new LegacySnapshotMerger(oldSnapshot, newSnapshot);
 
-    if (byNameAndType != byId) {
-      throw createUnmergeableException(oldDb, oldCol, oldStructure, changed, byNameAndType, byId);
-    }
-
-    if (byNameAndType == null && byId == null) {
-      Optional<? extends MetaIndex> oldMissedIndex = newCol.getAnyMissedIndex(oldCol, newStructure,
-          oldStructure, changed);
-
-      if (oldMissedIndex.isPresent()) {
-        throw createUnmergeableExceptionForMissing(oldDb, oldCol, oldStructure, changed,
-            oldMissedIndex.get());
-      }
-
-      parentBuilder.put(changed);
-    }
+    return legacyMerger.merge().build();
   }
-
-  private void merge(MetaDatabase db, MetaCollection col, ImmutableMetaDocPart oldStructure,
-      ImmutableMetaDocPart.Builder parentBuilder, ImmutableMetaScalar changed) {
-    MetaScalar byId = oldStructure.getScalar(changed.getIdentifier());
-    MetaScalar byType = oldStructure.getScalar(changed.getType());
-
-    if (byType != byId) {
-      throw createUnmergeableException(db, col, oldStructure, changed, byType, byId);
-    }
-    if (byType == null && byId == null) {
-      parentBuilder.put(changed);
-    }
-  }
-
-  @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
-  private void merge(MetaDatabase oldDb, MutableMetaCollection newCol,
-      ImmutableMetaCollection oldCol, MetaDocPart newStructure, ImmutableMetaDocPart oldStructure,
-      ImmutableMetaDocPart.Builder parentBuilder, ImmutableMetaIdentifiedDocPartIndex changed,
-      MetaElementState newState) throws UnmergeableException {
-    ImmutableMetaIdentifiedDocPartIndex byId = oldStructure.getMetaDocPartIndexByIdentifier(changed
-        .getIdentifier());
-    ImmutableMetaIdentifiedDocPartIndex bySameColumns = oldStructure.streamIndexes()
-        .filter(oldDocPartIndex -> oldDocPartIndex.hasSameColumns(changed))
-        .findAny()
-        .orElse(null);
-
-    switch (newState) {
-      default:
-      case NOT_CHANGED:
-      case NOT_EXISTENT:
-        throw new AssertionError("A modification was expected, but the new state is " + newState);
-      case ADDED:
-      case MODIFIED: {
-        Optional<? extends MetaIndex> anyRelatedIndex = newCol.getAnyRelatedIndex(oldCol,
-            newStructure, changed);
-
-        if (!anyRelatedIndex.isPresent()) {
-          throw createUnmergeableExceptionForOrphan(oldDb, oldCol, oldStructure, changed);
-        }
-
-        if (byId == null) {
-          parentBuilder.put(changed);
-          return;
-        }
-        assert byId != null;
-
-        ImmutableMetaIdentifiedDocPartIndex.Builder childBuilder =
-            new ImmutableMetaIdentifiedDocPartIndex.Builder(byId);
-
-        Iterator<ImmutableMetaDocPartIndexColumn> indexColumnIterator = changed.iteratorColumns();
-        while (indexColumnIterator.hasNext()) {
-          ImmutableMetaDocPartIndexColumn indexColumn = indexColumnIterator.next();
-          merge(oldDb, oldCol, oldStructure, byId, childBuilder, indexColumn);
-        }
-
-        parentBuilder.put(childBuilder);
-
-        break;
-      }
-      case REMOVED: {
-        Optional<? extends MetaIndex> oldMissedIndex = newCol.getAnyMissedIndex(oldCol, changed);
-
-        if (oldMissedIndex.isPresent()) {
-          throw createUnmergeableExceptionForMissing(oldDb, oldCol, oldStructure, changed,
-              oldMissedIndex.get());
-        }
-
-        if (byId == null || bySameColumns == null) {
-          /*
-           * it has been removed on another transaction or created and removed on the current one.
-           * No change must be done
-           */
-          return;
-        }
-        assert byId != null;
-        assert bySameColumns != null;
-        /*
-         * In this case, we can delegate on the backend transaction check. If it thinks everything
-         * is fine, we can remove the element. If it thinks there is an error, then we have to
-         * rollback the transaction.
-         */
-        parentBuilder.remove(byId);
-      }
-    }
-  }
-
-  private void merge(MetaDatabase db, MetaCollection col, MetaDocPart docPart,
-      ImmutableMetaIdentifiedDocPartIndex oldStructure,
-      ImmutableMetaIdentifiedDocPartIndex.Builder parentBuilder,
-      ImmutableMetaDocPartIndexColumn changed) throws UnmergeableException {
-    ImmutableMetaDocPartIndexColumn byIdentifier = oldStructure
-        .getMetaDocPartIndexColumnByIdentifier(changed.getIdentifier());
-    ImmutableMetaDocPartIndexColumn byPosition = oldStructure.getMetaDocPartIndexColumnByPosition(
-        changed.getPosition());
-
-    if (byIdentifier != byPosition) {
-      throw createUnmergeableException(db, col, docPart, oldStructure, changed, byIdentifier,
-          byPosition);
-    }
-    if (byIdentifier == null && byPosition == null) {
-      parentBuilder.add(changed);
-    }
-  }
-
-  @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE")
-  private void merge(MetaDatabase oldDb, MutableMetaCollection newStructure,
-      ImmutableMetaCollection oldStructure,
-      ImmutableMetaCollection.Builder parentBuilder, MutableMetaIndex changed,
-      MetaElementState newState) throws UnmergeableException {
-    ImmutableMetaIndex byName = oldStructure.getMetaIndexByName(changed.getName());
-
-    switch (newState) {
-      default:
-      case NOT_CHANGED:
-      case NOT_EXISTENT:
-        throw new AssertionError("A modification was expected, but the new state is " + newState);
-      case ADDED:
-      case MODIFIED: {
-        Optional<? extends MetaIndex> anyConflictingIndex = newStructure.getAnyConflictingIndex(
-            oldStructure, changed);
-
-        if (anyConflictingIndex.isPresent()) {
-          throw createUnmergeableException(oldDb, oldStructure, changed, anyConflictingIndex.get());
-        }
-
-        Optional<? extends MetaDocPart> anyDocPartWithMissingDocPartIndex =
-            newStructure.getAnyDocPartWithMissedDocPartIndex(oldStructure, changed);
-
-        if (anyDocPartWithMissingDocPartIndex.isPresent()) {
-          throw createUnmergeableExceptionForMissing(oldDb, oldStructure, changed,
-              anyDocPartWithMissingDocPartIndex.get());
-        }
-
-        if (byName == null) {
-          parentBuilder.put(changed.immutableCopy());
-          return;
-        }
-        assert byName != null;
-
-        ImmutableMetaIndex.Builder childBuilder = new ImmutableMetaIndex.Builder(byName);
-
-        for (ImmutableMetaIndexField addedMetaIndexField : changed.getAddedMetaIndexFields()) {
-          merge(oldDb, oldStructure, byName, childBuilder, addedMetaIndexField);
-        }
-
-        parentBuilder.put(childBuilder);
-
-        break;
-      }
-      case REMOVED: {
-        Optional<? extends MetaIdentifiedDocPartIndex> orphanDocPartIndex = newStructure
-            .getAnyOrphanDocPartIndex(oldStructure, changed);
-
-        if (orphanDocPartIndex.isPresent()) {
-          throw createUnmergeableExceptionForOrphan(oldDb, oldStructure, changed, orphanDocPartIndex
-              .get());
-        }
-
-        if (byName == null) {
-          /*
-           * it has been removed on another transaction or created and removed on the current one.
-           * No change must be done
-           */
-          return;
-        }
-        assert byName != null;
-
-        /*
-         * In this case, we can delegate on the backend transaction check. If it thinks everything
-         * is fine, we can remove the element. If it thinks there is an error, then we have to
-         * rollback the transaction.
-         */
-        parentBuilder.remove(byName);
-      }
-    }
-  }
-
-  private void merge(MetaDatabase db, MetaCollection col, ImmutableMetaIndex oldStructure,
-      ImmutableMetaIndex.Builder parentBuilder, ImmutableMetaIndexField changed) throws
-      UnmergeableException {
-    ImmutableMetaIndexField byTableRefAndName = oldStructure.getMetaIndexFieldByTableRefAndName(
-        changed.getTableRef(), changed.getName());
-    ImmutableMetaIndexField byPosition = oldStructure.getMetaIndexFieldByPosition(changed
-        .getPosition());
-
-    if (byTableRefAndName != byPosition) {
-      throw createUnmergeableException(db, col, oldStructure, changed, byTableRefAndName,
-          byPosition);
-    }
-    if (byTableRefAndName == null && byPosition == null) {
-      parentBuilder.add(changed);
-    }
-  }
-
-  private UnmergeableException createUnmergeableException(
-      MetaDatabase newDb, ImmutableMetaDatabase byName, ImmutableMetaDatabase byId) {
-
-    if (byName != null) {
-      throw new UnmergeableException(oldSnapshot, newSnapshot,
-          "There is a previous database whose name is " + byName.getName()
-          + " that has a different id. The previous element id is "
-          + byName.getIdentifier() + " and the new one is " + newDb.getIdentifier());
-    } else {
-      assert byId != null;
-      throw new UnmergeableException(oldSnapshot, newSnapshot,
-          "There is a previous database whose id is " + byId.getIdentifier()
-          + " that has a different name. The previous element name is "
-          + byId.getName() + " and the new one is " + newDb.getName());
-    }
-  }
-
-  private UnmergeableException createUnmergeableException(
-      MetaDatabase db,
-      MutableMetaCollection newCol, ImmutableMetaCollection byName, ImmutableMetaCollection byId) {
-
-    if (byName != null) {
-      throw new UnmergeableException(oldSnapshot, newSnapshot,
-          "There is a previous collection on " + db + " whose name is "
-          + byName.getName() + " that has a different id. The previous "
-          + "element id is " + byName.getIdentifier() + " and the new one is "
-          + newCol.getIdentifier());
-    } else {
-      assert byId != null;
-      throw new UnmergeableException(oldSnapshot, newSnapshot,
-          "There is a previous collection on " + db + " whose id is "
-          + byId.getIdentifier() + " that has a different name. The previous "
-          + "element name is " + byId.getName() + " and the new one is "
-          + newCol.getIdentifier());
-    }
-  }
-
-  private UnmergeableException createUnmergeableException(
-      MetaDatabase db,
-      MetaCollection col, MutableMetaDocPart changed, ImmutableMetaDocPart byRef,
-      ImmutableMetaDocPart byId) {
-    if (byRef != null) {
-      throw new UnmergeableException(oldSnapshot, newSnapshot,
-          "There is a previous doc part on " + db + "." + col + " whose ref is "
-          + byRef.getTableRef() + " that has a different id. The previous "
-          + "element id is " + byRef.getIdentifier() + " and the new one is "
-          + changed.getIdentifier());
-    } else {
-      assert byId != null;
-      throw new UnmergeableException(oldSnapshot, newSnapshot,
-          "There is a previous doc part on " + db + "." + col + " whose id is "
-          + byId.getIdentifier() + " that has a different ref. The previous "
-          + "element ref is " + byId.getTableRef() + " and the new one is "
-          + changed.getTableRef());
-    }
-  }
-
-  private UnmergeableException createUnmergeableException(
-      MetaDatabase db, MetaCollection col, MetaDocPart docPart, ImmutableMetaField changed,
-      ImmutableMetaField byNameAndType, ImmutableMetaField byId) {
-    if (byNameAndType != null) {
-      throw new UnmergeableException(oldSnapshot, newSnapshot,
-          "There is a previous field on doc part " + db + "." + col + "." + docPart + " whose "
-          + "name is " + byNameAndType.getName() + " and type is "
-          + byNameAndType.getType() + " that has a different id. The previous "
-          + "element id is " + byNameAndType.getIdentifier() + " and the new "
-          + "one is " + changed.getIdentifier());
-    } else {
-      assert byId != null;
-      throw new UnmergeableException(oldSnapshot, newSnapshot,
-          "There is a previous field on doc part " + db.getIdentifier() + "." + col.getIdentifier()
-          + "." + docPart.getIdentifier() + " whose id is " + byId.getIdentifier()
-          + " that has a different name or "
-          + "type. The previous element name is " + byId.getName() + " and its "
-          + "type is " + byId.getType() + ". The name of the new one is "
-          + changed.getName() + " and its type is " + changed.getType());
-    }
-  }
-
-  private UnmergeableException createUnmergeableException(
-      MetaDatabase db, MetaCollection col, MetaDocPart docPart, ImmutableMetaScalar changed,
-      MetaScalar byType, MetaScalar byId) {
-    if (byType != null) {
-      throw new UnmergeableException(oldSnapshot, newSnapshot,
-          "There is a previous meta scalar on " + db.getIdentifier() + "."
-          + col.getIdentifier() + "." + docPart.getIdentifier() + " whose "
-          + "type is " + changed.getType() + " but its identifier is "
-          + byType.getIdentifier() + ". The identifier of the new one is "
-          + changed.getIdentifier()
-      );
-    } else {
-      assert byId != null;
-      throw new UnmergeableException(oldSnapshot, newSnapshot,
-          "There is a previous meta scalar on " + db.getIdentifier() + "."
-          + col.getIdentifier() + "." + docPart.getIdentifier() + " whose "
-          + "identifier is " + changed.getIdentifier() + " but its type is "
-          + byId.getType() + ". The type of the new one is " + changed.getType()
-      );
-    }
-  }
-
-  private UnmergeableException createUnmergeableException(
-      MetaDatabase db, MetaCollection col, MetaDocPart docPart, MetaIdentifiedDocPartIndex index,
-      ImmutableMetaDocPartIndexColumn changed,
-      ImmutableMetaDocPartIndexColumn byIdentifier, ImmutableMetaDocPartIndexColumn byPosition) {
-    if (byIdentifier != null) {
-      throw new UnmergeableException(oldSnapshot, newSnapshot,
-          "There is a previous field on doc part index " + db.getIdentifier() + "." + col
-          .getIdentifier() + "." + docPart.getIdentifier() + "." + index.getIdentifier() + " whose "
-          + "identifier is " + byIdentifier.getIdentifier()
-          + " that has a different position. The previous "
-          + "element position is " + byIdentifier.getPosition() + " and the new "
-          + "one is " + changed.getPosition());
-    } else {
-      assert byPosition != null;
-      throw new UnmergeableException(oldSnapshot, newSnapshot,
-          "There is a previous field on doc part index " + db.getIdentifier() + "." + col
-          .getIdentifier()
-          + "." + docPart.getIdentifier() + "." + index.getIdentifier() + " whose position is "
-          + byPosition.getPosition() + " that has a different name or "
-          + "type. The previous element identifier is " + byPosition.getIdentifier()
-          + ". The name of the new one is " + changed.getIdentifier());
-    }
-  }
-
-  private UnmergeableException createUnmergeableException(
-      MetaDatabase db, MetaCollection col, MetaIndex index, ImmutableMetaIndexField changed,
-      ImmutableMetaIndexField byTableRefAndName, ImmutableMetaIndexField byPosition) {
-    if (byTableRefAndName != null) {
-      throw new UnmergeableException(oldSnapshot, newSnapshot,
-          "There is a previous field on index " + db + "." + col + "." + index + " whose "
-          + "tableRef is " + byTableRefAndName.getTableRef() + " and name is "
-          + byTableRefAndName.getName() + " that has a different position. The previous "
-          + "element position is " + byTableRefAndName.getPosition() + " and the new "
-          + "one is " + changed.getPosition());
-    } else {
-      assert byPosition != null;
-      throw new UnmergeableException(oldSnapshot, newSnapshot,
-          "There is a previous field on index " + db + "." + col
-          + "." + index + " whose position is " + byPosition.getPosition()
-          + " that has a different tableRef or "
-          + "name. The previous element tableRef is " + byPosition.getTableRef() + " and its "
-          + "name is " + byPosition.getName() + ". The tableRef of the new one is "
-          + changed.getTableRef() + " and its name is " + changed.getName());
-    }
-  }
-
-  private UnmergeableException createUnmergeableException(
-      MetaDatabase db,
-      MetaCollection col, MutableMetaIndex changed, MetaIndex oldIndex) {
-    throw new UnmergeableException(oldSnapshot, newSnapshot,
-        "There is a previous index on " + db + "." + col + "." + oldIndex
-        + " that conflict with new index "
-        + changed);
-  }
-
-  private UnmergeableException createUnmergeableExceptionForMissing(
-      MetaDatabase db,
-      MetaCollection col, MetaDocPart docPart, MetaField changed, MetaIndex oldMissedIndex) {
-    throw new UnmergeableException(oldSnapshot, newSnapshot,
-        "There is a previous index on " + db + "." + col
-        + " whose name is " + oldMissedIndex.getName()
-        + " associated with new doc part field " + docPart + "."
-        + changed + " and the corresponding doc part index has not been created.");
-  }
-
-  private UnmergeableException createUnmergeableExceptionForMissing(
-      MetaDatabase db, MetaCollection col, MetaDocPart docPart, MetaIdentifiedDocPartIndex changed,
-      MetaIndex oldMissedIndex) {
-    throw new UnmergeableException(oldSnapshot, newSnapshot,
-        "There is a previous doc part index " + db + "." + col + "." + docPart + "."
-        + oldMissedIndex
-        + " that is compatible with the removed doc part index "
-        + db.getIdentifier() + "." + col.getIdentifier() + "." + docPart.getIdentifier() + "."
-        + changed.getIdentifier());
-  }
-
-  private UnmergeableException createUnmergeableExceptionForMissing(
-      MetaDatabase db,
-      MetaCollection col, MutableMetaIndex changed, MetaDocPart oldDocPartForMissedIndex) {
-    throw new UnmergeableException(oldSnapshot, newSnapshot,
-        "There should be a doc part index on " + db + "." + col + "." + oldDocPartForMissedIndex
-        + " associated only with new index "
-        + changed + " that has not been created.");
-  }
-
-  private UnmergeableException createUnmergeableExceptionForOrphan(
-      MetaDatabase db,
-      MetaCollection col,
-      MetaDocPart docPart,
-      MetaIdentifiedDocPartIndex changed) {
-    throw new UnmergeableException(oldSnapshot, newSnapshot,
-        "There is a new doc part index " + db.getIdentifier() + "." + col.getIdentifier() + "."
-        + docPart.getIdentifier() + "." + changed.getIdentifier()
-        + " that has no index associated");
-  }
-
-  private UnmergeableException createUnmergeableExceptionForOrphan(
-      MetaDatabase db,
-      MetaCollection col, 
-      MutableMetaIndex changed,
-      MetaIdentifiedDocPartIndex oldOrphanDocPartIndex) {
-    throw new UnmergeableException(oldSnapshot, newSnapshot,
-        "There is a previous doc part index on " + db.getIdentifier() + "." + oldOrphanDocPartIndex
-        .getIdentifier()
-        + " associated only with removed index "
-        + changed + " that has not been deleted.");
-  }
-
 }

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/ByStateStrategyPicker.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/ByStateStrategyPicker.java
@@ -18,6 +18,14 @@
 
 package com.torodb.metainfo.cache.mvcc.merge;
 
+/**
+ * A {@link MergeStrategyPicker} that choose between strategies by the
+ * {@link MergeContext#getChange() kind of change}.
+ * @param <P> The commited parent class
+ * @param <C> The changed element class
+ * @param <PBT> The class that is used to create new commited parents
+ * @param <CtxT> The context class
+ */
 public class ByStateStrategyPicker<P, C, PBT, CtxT extends MergeContext<P, C>>
     implements MergeStrategyPicker<P, C, PBT, CtxT> {
 

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/ByStateStrategyPicker.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/ByStateStrategyPicker.java
@@ -1,0 +1,57 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge;
+
+public class ByStateStrategyPicker<P, C, PBT, CtxT extends MergeContext<P, C>>
+    implements MergeStrategyPicker<P, C, PBT, CtxT> {
+
+  @SuppressWarnings("checkstyle:LineLength")
+  private final MergeStrategyPicker<P, C, PBT, CtxT> onAdd;
+  @SuppressWarnings("checkstyle:LineLength")
+  private final MergeStrategyPicker<P, C, PBT, CtxT> onModify;
+  @SuppressWarnings("checkstyle:LineLength")
+  private final MergeStrategyPicker<P, C, PBT, CtxT> onRemove;
+
+  public ByStateStrategyPicker(
+      MergeStrategyPicker<P, C, PBT, CtxT> onAdd,
+      MergeStrategyPicker<P, C, PBT, CtxT> onModify,
+      MergeStrategyPicker<P, C, PBT, CtxT> onRemove) {
+    this.onAdd = onAdd;
+    this.onModify = onModify;
+    this.onRemove = onRemove;
+  }
+
+  @Override
+  public MergeStrategy<P, C, PBT, CtxT> pick(CtxT context) {
+    switch (context.getChange()) {
+      default:
+      case NOT_CHANGED:
+      case NOT_EXISTENT:
+        throw new AssertionError("A modification was expected, but the new state is "
+            + context.getChanged());
+      case ADDED:
+        return onAdd.pick(context);
+      case MODIFIED:
+        return onModify.pick(context);
+      case REMOVED:
+        return onRemove.pick(context);
+    }
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/ChildrenMergePartialStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/ChildrenMergePartialStrategy.java
@@ -1,0 +1,97 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge;
+
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.InnerErrorMessageFactory;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+
+import java.util.stream.Stream;
+
+/**
+ * @param <P> The commited parent type
+ * @param <C> The changed self type
+ * @param <PBT> The parent builder type
+ * @param <CtxT> The contex type
+ * @param <CBT> The self builder type
+ * @param <IST> The self immutable type
+ */
+public abstract class ChildrenMergePartialStrategy<P, C, PBT, CtxT extends MergeContext<P, C>, 
+    CBT, IST> implements PartialMergeStrategy<P, C, PBT, CtxT> {
+
+  @Override
+  public abstract boolean appliesTo(CtxT context);
+
+  @Override
+  public ExecutionResult<P> execute(CtxT context, PBT parentBuilder) throws
+      IllegalArgumentException {
+    CBT builder = createSelfBuilder(context);
+
+    Stream<ExecutionResult<IST>> recursiveResultStream = streamChildResults(context, builder);
+
+    ExecutionResult<P> result = mergeChildResults(context, recursiveResultStream);
+
+    if (result.isSuccess()) {
+      changeParent(parentBuilder, builder);
+    }
+
+    return result;
+  }
+
+  protected abstract CBT createSelfBuilder(CtxT context);
+
+  protected abstract Stream<ExecutionResult<IST>> streamChildResults(CtxT context, CBT selfBuilder);
+
+  protected abstract void changeParent(PBT parentBuilder, CBT selfBuilder);
+
+  protected abstract String describeChanged(ParentDescriptionFun<P> parentDescFun, P parent,
+      IST immutableSelf);
+
+  /**
+   * Given a context and a stream with the result of the sub structures, returns a single
+   * {@link ExecutionResult} that describes the first error it found or a
+   * {@link ExecutionResult#success() success} if there is no error.
+   */
+  private <S> ExecutionResult<P> mergeChildResults(CtxT context,
+      Stream<ExecutionResult<IST>> childResults) {
+
+    P parent = context.getCommitedParent();
+
+    return childResults.filter(result -> !result.isSuccess())
+        .map(result -> result.map(docPartErrorFactory -> createErrorMsgFactory(
+            docPartErrorFactory,
+            parent)
+        ))
+        .findAny()
+        .orElse(ExecutionResult.success());
+  }
+
+  protected InnerErrorMessageFactory<P> createErrorMsgFactory(
+      InnerErrorMessageFactory<IST> docPartErrorFactory, P parent) {
+
+    return (parentDescFun) -> {
+      ParentDescriptionFun<IST> selfDescFun = (self) -> describeChanged(
+          parentDescFun,
+          parent,
+          self
+      );
+      return docPartErrorFactory.apply(selfDescFun);
+    };
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/ChildrenMergePartialStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/ChildrenMergePartialStrategy.java
@@ -18,12 +18,15 @@
 
 package com.torodb.metainfo.cache.mvcc.merge;
 
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.InnerErrorMessageFactory;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.InnerErrorMessageFactory;
+import com.torodb.metainfo.cache.mvcc.merge.result.ParentDescriptionFun;
 
 import java.util.stream.Stream;
 
 /**
+ * An abstract {@link PartialMergeStrategy} designed to be extended by strategies that delegate
+ * on children elements strategies.
  * @param <P> The commited parent type
  * @param <C> The changed self type
  * @param <PBT> The parent builder type
@@ -53,12 +56,32 @@ public abstract class ChildrenMergePartialStrategy<P, C, PBT, CtxT extends Merge
     return result;
   }
 
+  /**
+   * Returns a new builder that can be used to create the merged element.
+   */
   protected abstract CBT createSelfBuilder(CtxT context);
 
+  /**
+   * Returns a stream with the result of merge children.
+   * @param context the merging context
+   * @param selfBuilder the builder used to create the merged element
+   */
   protected abstract Stream<ExecutionResult<IST>> streamChildResults(CtxT context, CBT selfBuilder);
 
+  /**
+   * The method called to add the created element to the parent builder.
+   * @param parentBuilder the parent builder
+   * @param selfBuilder the self builder where children have been already merged
+   */
   protected abstract void changeParent(PBT parentBuilder, CBT selfBuilder);
 
+  /**
+   * A method that describe the changed element.
+   * @param parentDescFun a function that describes elements of the parent class
+   * @param parent the parent of the current element
+   * @param immutableSelf the instance to be described
+   * @return the description of the given instance
+   */
   protected abstract String describeChanged(ParentDescriptionFun<P> parentDescFun, P parent,
       IST immutableSelf);
 

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/DefaultMergeContext.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/DefaultMergeContext.java
@@ -22,30 +22,40 @@ import com.torodb.core.transaction.metainf.ChangedElement;
 import com.torodb.core.transaction.metainf.MetaElementState;
 
 /**
- *
+ * A pojo implementation of {@link MergeContext}.
  */
-public class DefaultMergeContext<P, C, UncommitedParentT> extends PojoMergeContext<P, C> {
-  private final UncommitedParentT uncommitedParent;
+public class DefaultMergeContext<CommitedParentT, ChangedT>
+    implements MergeContext<CommitedParentT, ChangedT> {
 
-  public DefaultMergeContext(
-      P commitedParent,
-      C changed,
-      MetaElementState change,
-      UncommitedParentT uncommitedParent) {
-    super(commitedParent, changed, change);
-    this.uncommitedParent = uncommitedParent;
+  private final CommitedParentT commitedParent;
+  private final ChangedT changed;
+  private final MetaElementState change;
+
+  public DefaultMergeContext(CommitedParentT commitedParent, ChangedT changed,
+      MetaElementState change) {
+    this.commitedParent = commitedParent;
+    this.changed = changed;
+    this.change = change;
   }
 
-  public DefaultMergeContext(
-      P commitedParent,
-      ChangedElement<? extends C> changed,
-      UncommitedParentT uncommitedParent) {
-    super(commitedParent, changed);
-    this.uncommitedParent = uncommitedParent;
+  public DefaultMergeContext(CommitedParentT commitedParent,
+      ChangedElement<? extends ChangedT> changed) {
+    this(commitedParent, changed.getElement(), changed.getChange());
   }
 
-  public UncommitedParentT getUncommitedParent() {
-    return uncommitedParent;
+  @Override
+  public CommitedParentT getCommitedParent() {
+    return commitedParent;
+  }
+
+  @Override
+  public ChangedT getChanged() {
+    return changed;
+  }
+
+  @Override
+  public MetaElementState getChange() {
+    return change;
   }
 
 }

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/DefaultMergeContext.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/DefaultMergeContext.java
@@ -1,0 +1,51 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge;
+
+import com.torodb.core.transaction.metainf.ChangedElement;
+import com.torodb.core.transaction.metainf.MetaElementState;
+
+/**
+ *
+ */
+public class DefaultMergeContext<P, C, UncommitedParentT> extends PojoMergeContext<P, C> {
+  private final UncommitedParentT uncommitedParent;
+
+  public DefaultMergeContext(
+      P commitedParent,
+      C changed,
+      MetaElementState change,
+      UncommitedParentT uncommitedParent) {
+    super(commitedParent, changed, change);
+    this.uncommitedParent = uncommitedParent;
+  }
+
+  public DefaultMergeContext(
+      P commitedParent,
+      ChangedElement<? extends C> changed,
+      UncommitedParentT uncommitedParent) {
+    super(commitedParent, changed);
+    this.uncommitedParent = uncommitedParent;
+  }
+
+  public UncommitedParentT getUncommitedParent() {
+    return uncommitedParent;
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/DoNothingMergeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/DoNothingMergeStrategy.java
@@ -1,0 +1,37 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge;
+
+/**
+ *
+ */
+public class DoNothingMergeStrategy<C, P, PBT, CtxT extends MergeContext<P, C>>
+    implements MergeStrategy<P, C, PBT, CtxT> {
+
+  @Override
+  public ExecutionResult<P> execute(CtxT context, PBT parentBuilder) {
+    return ExecutionResult.success();
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getCanonicalName();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/DoNothingMergeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/DoNothingMergeStrategy.java
@@ -18,6 +18,8 @@
 
 package com.torodb.metainfo.cache.mvcc.merge;
 
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+
 /**
  *
  */

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/ErrorExecutionResult.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/ErrorExecutionResult.java
@@ -1,0 +1,47 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge;
+
+import java.util.Optional;
+
+/**
+ *
+ */
+class ErrorExecutionResult<P, C> extends ExecutionResult<P> {
+  /**
+   * Returns the error message on a format that follow {@link MessageFormat} syntax, where
+   * the first argument is a text that identifies the parent and the second a text that identifies
+   * the changed element.
+   */
+  private final ExecutionResult.PrettyErrorMessageFactory<P> messageFactory;
+
+  public ErrorExecutionResult(String ruleId, InnerErrorMessageFactory<P> messageFactory) {
+    this.messageFactory = new PrettyErrorMessageFactory<>(ruleId, messageFactory);
+  }
+
+  @Override
+  public boolean isSuccess() {
+    return false;
+  }
+
+  @Override
+  public Optional<PrettyErrorMessageFactory<P>> getErrorMessageFactory() {
+    return Optional.of(messageFactory);
+  }
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/ExecutionResult.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/ExecutionResult.java
@@ -1,0 +1,100 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+
+/**
+ * The result state of an execution of a {@link MergeStrategy}.
+ */
+public abstract class ExecutionResult<P> {
+
+  @SuppressWarnings("unchecked")
+  public static <P> ExecutionResult<P> success() {
+    return (ExecutionResult<P>) SuccessExecutionResult.INSTANCE;
+  }
+
+  public static <P> ExecutionResult<P> error(
+      String ruleId, InnerErrorMessageFactory<P> errFactory) {
+    return new ErrorExecutionResult<>(ruleId, errFactory);
+  }
+
+  public static <P> ExecutionResult<P> error(
+      Class<?> ruleClass,
+      InnerErrorMessageFactory<P> errFactory) {
+    return error(ruleClass.getCanonicalName(), errFactory);
+  }
+
+  public abstract boolean isSuccess();
+
+  public abstract Optional<PrettyErrorMessageFactory<P>> getErrorMessageFactory();
+
+  /**
+   * Returns a new {@link ExecutionResult} that maps the error message to a new function.
+   *
+   * @param trans a function that maps from this error message to the new one.
+   */
+  public <P2> ExecutionResult<P2> map(
+      Function<InnerErrorMessageFactory<P>, InnerErrorMessageFactory<P2>> trans) {
+    if (this.isSuccess()) {
+      return ExecutionResult.success();
+    } else {
+      return new MapErrorExecutionResult<>(this, trans);
+    }
+  }
+
+  @FunctionalInterface
+  public static interface InnerErrorMessageFactory<P>
+      extends Function<ParentDescriptionFun<P>, String> {
+
+    @Override
+    public String apply(ParentDescriptionFun<P> parentDescriptionFun);
+
+  }
+
+  @FunctionalInterface
+  public static interface ParentDescriptionFun<P> extends Function<P, String> {
+
+    @Override
+    public String apply(P parent);
+  }
+
+  public static class PrettyErrorMessageFactory<P>
+      implements Function<ParentDescriptionFun<P>, String> {
+    private final String ruleId;
+    private final InnerErrorMessageFactory<P> delegate;
+
+    public PrettyErrorMessageFactory(String ruleId, InnerErrorMessageFactory<P> delegate) {
+      this.ruleId = ruleId;
+      this.delegate = delegate;
+    }
+
+    @Override
+    public String apply(ParentDescriptionFun<P> parentDescriptionFun) {
+      return ruleId + ": " + delegate.apply(parentDescriptionFun);
+    }
+
+    public <P2> PrettyErrorMessageFactory<P2> transform(
+        Function<InnerErrorMessageFactory<P>, InnerErrorMessageFactory<P2>> transformation) {
+      return new PrettyErrorMessageFactory<>(ruleId, transformation.apply(delegate));
+    }
+  }
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/ExtendedMergeContext.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/ExtendedMergeContext.java
@@ -22,40 +22,30 @@ import com.torodb.core.transaction.metainf.ChangedElement;
 import com.torodb.core.transaction.metainf.MetaElementState;
 
 /**
- *
+ * A {@link MergeContext} that contains the uncommited parent.
  */
-public class PojoMergeContext<CommitedParentT, ChangedT>
-    implements MergeContext<CommitedParentT, ChangedT> {
+public class ExtendedMergeContext<P, C, UncommitedParentT> extends DefaultMergeContext<P, C> {
+  private final UncommitedParentT uncommitedParent;
 
-  private final CommitedParentT commitedParent;
-  private final ChangedT changed;
-  private final MetaElementState change;
-
-  public PojoMergeContext(CommitedParentT commitedParent, ChangedT changed,
-      MetaElementState change) {
-    this.commitedParent = commitedParent;
-    this.changed = changed;
-    this.change = change;
+  public ExtendedMergeContext(
+      P commitedParent,
+      C changed,
+      MetaElementState change,
+      UncommitedParentT uncommitedParent) {
+    super(commitedParent, changed, change);
+    this.uncommitedParent = uncommitedParent;
   }
 
-  public PojoMergeContext(CommitedParentT commitedParent, 
-      ChangedElement<? extends ChangedT> changed) {
-    this(commitedParent, changed.getElement(), changed.getChange());
+  public ExtendedMergeContext(
+      P commitedParent,
+      ChangedElement<? extends C> changed,
+      UncommitedParentT uncommitedParent) {
+    super(commitedParent, changed);
+    this.uncommitedParent = uncommitedParent;
   }
 
-  @Override
-  public CommitedParentT getCommitedParent() {
-    return commitedParent;
-  }
-
-  @Override
-  public ChangedT getChanged() {
-    return changed;
-  }
-
-  @Override
-  public MetaElementState getChange() {
-    return change;
+  public UncommitedParentT getUncommitedParent() {
+    return uncommitedParent;
   }
 
 }

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/FirstToApplyStrategyPicker.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/FirstToApplyStrategyPicker.java
@@ -24,7 +24,16 @@ import org.apache.logging.log4j.Logger;
 import java.util.Collection;
 import java.util.Optional;
 
-
+/**
+ * A {@link MergeStrategyPicker} that contains a list of partial strategies and picks the first
+ * strategy that 
+ * {@link PartialMergeStrategy#appliesTo(com.torodb.metainfo.cache.mvcc.merge.MergeContext) applies}
+ * on the given context.
+ * @param <P> the type of the commited parent
+ * @param <C> the type of the changed element
+ * @param <PBT> the builder class to create new parents
+ * @param <CtxT> the context type
+ */
 public class FirstToApplyStrategyPicker<P, C, PBT, CtxT extends MergeContext<P, C>>
     implements MergeStrategyPicker<P, C, PBT, CtxT> {
 

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/FirstToApplyStrategyPicker.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/FirstToApplyStrategyPicker.java
@@ -1,0 +1,68 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge;
+
+import com.torodb.core.d2r.D2RLoggerFactory;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Collection;
+import java.util.Optional;
+
+
+public class FirstToApplyStrategyPicker<P, C, PBT, CtxT extends MergeContext<P, C>>
+    implements MergeStrategyPicker<P, C, PBT, CtxT> {
+
+  private static final Logger LOGGER = D2RLoggerFactory.get(FirstToApplyStrategyPicker.class);
+  private final Collection<PartialMergeStrategy<P, C, PBT, CtxT>> strategies;
+  private final MergeStrategy<P, C, PBT, CtxT> onOtherCase;
+
+  public FirstToApplyStrategyPicker(Collection<PartialMergeStrategy<P, C, PBT, CtxT>> strategies) {
+    this(strategies, new DoNothingMergeStrategy<>());
+  }
+
+  public FirstToApplyStrategyPicker(Collection<PartialMergeStrategy<P, C, PBT, CtxT>> strategies,
+      MergeStrategy<P, C, PBT, CtxT> onOtherCase) {
+    this.strategies = strategies;
+    this.onOtherCase = onOtherCase;
+  }
+
+  @Override
+  public MergeStrategy<P, C, PBT, CtxT> pick(CtxT context) {
+    Optional<PartialMergeStrategy<P, C, PBT, CtxT>> subStrategy = strategies.stream()
+        .filter(s -> filter(s, context))
+        .findFirst();
+    if (subStrategy.isPresent()) {
+      return subStrategy.get();
+    } else {
+      LOGGER.debug("As no other strategy applies, the default strategy {} is used to execute {}",
+          onOtherCase, context);
+      return onOtherCase;
+    }
+  }
+
+  private boolean filter(PartialMergeStrategy<P, C, PBT, CtxT> strategy, CtxT context) {
+    boolean applies = strategy.appliesTo(context);
+    if (applies) {
+      LOGGER.debug("Using {} to execute {}", strategy, context);
+    } else {
+      LOGGER.trace("Strategy {} does not apply to {}", strategy, context);
+    }
+    return applies;
+  }
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/MapErrorExecutionResult.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/MapErrorExecutionResult.java
@@ -1,0 +1,49 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ *
+ */
+class MapErrorExecutionResult<P1, P2> extends ExecutionResult<P2> {
+
+  private final ExecutionResult<P1> delegate;
+  private final Function<InnerErrorMessageFactory<P1>, InnerErrorMessageFactory<P2>> transformation;
+
+  public MapErrorExecutionResult(ExecutionResult<P1> delegate,
+      Function<InnerErrorMessageFactory<P1>, InnerErrorMessageFactory<P2>> transformation) {
+    this.delegate = delegate;
+    this.transformation = transformation;
+  }
+
+  @Override
+  public boolean isSuccess() {
+    return delegate.isSuccess();
+  }
+
+  @Override
+  public Optional<PrettyErrorMessageFactory<P2>> getErrorMessageFactory() {
+    return delegate.getErrorMessageFactory()
+        .map(factory -> factory.transform(transformation));
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/MergeContext.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/MergeContext.java
@@ -21,14 +21,20 @@ package com.torodb.metainfo.cache.mvcc.merge;
 import com.torodb.core.transaction.metainf.MetaElementState;
 
 /**
- *
+ * The context of a metainformation merge phase.
  */
 public interface MergeContext<CommitedParentT, ChangedT> {
 
   CommitedParentT getCommitedParent();
 
+  /**
+   * The element that has changed and it is being merged right now.
+   */
   ChangedT getChanged();
 
+  /**
+   * The kind of change.
+   */
   MetaElementState getChange();
 
 }

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/MergeContext.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/MergeContext.java
@@ -1,0 +1,34 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge;
+
+import com.torodb.core.transaction.metainf.MetaElementState;
+
+/**
+ *
+ */
+public interface MergeContext<CommitedParentT, ChangedT> {
+
+  CommitedParentT getCommitedParent();
+
+  ChangedT getChanged();
+
+  MetaElementState getChange();
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/MergeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/MergeStrategy.java
@@ -1,0 +1,28 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge;
+
+/**
+ *
+ */
+public interface MergeStrategy<P, C, PBT, CtxT extends MergeContext<P, C>> {
+
+  ExecutionResult<P> execute(CtxT context, PBT parentBuilder);
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/MergeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/MergeStrategy.java
@@ -18,8 +18,14 @@
 
 package com.torodb.metainfo.cache.mvcc.merge;
 
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+
 /**
- *
+ * A rule or strategy to merge an element.
+ * @param <P> the type of the commited parent
+ * @param <C> the type of the changed element
+ * @param <PBT> the builder class to create new parents
+ * @param <CtxT> the context type
  */
 public interface MergeStrategy<P, C, PBT, CtxT extends MergeContext<P, C>> {
 

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/MergeStrategyPicker.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/MergeStrategyPicker.java
@@ -18,6 +18,13 @@
 
 package com.torodb.metainfo.cache.mvcc.merge;
 
+/**
+ * A class used to pick a {@link MergeStrategy} given a context.
+ * @param <P> the type of the commited parent
+ * @param <C> the type of the changed element
+ * @param <PBT> the builder class to create new parents
+ * @param <CtxT> the context type
+ */
 public interface MergeStrategyPicker<P, C, PBT, CtxT extends MergeContext<P, C>> {
 
   MergeStrategy<P, C, PBT, CtxT> pick(CtxT context);

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/MergeStrategyPicker.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/MergeStrategyPicker.java
@@ -1,0 +1,25 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge;
+
+public interface MergeStrategyPicker<P, C, PBT, CtxT extends MergeContext<P, C>> {
+
+  MergeStrategy<P, C, PBT, CtxT> pick(CtxT context);
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/PartialMergeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/PartialMergeStrategy.java
@@ -18,12 +18,22 @@
 
 package com.torodb.metainfo.cache.mvcc.merge;
 
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+
 /**
- *
+ * A {@link MergeStrategy} that can only be executed on conditions specified by
+ * {@link #appliesTo(com.torodb.metainfo.cache.mvcc.merge.MergeContext)}.
+ * @param <P> the type of the commited parent
+ * @param <C> the type of the changed element
+ * @param <PBT> the builder class to create new parents
+ * @param <CtxT> the context type
  */
 public interface PartialMergeStrategy<P, C, PBT, CtxT extends MergeContext<P, C>>
     extends MergeStrategy<P, C, PBT, CtxT> {
 
+  /**
+   * Returns true if this strategy can be applied on the given context.
+   */
   public boolean appliesTo(CtxT context);
 
   /**

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/PartialMergeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/PartialMergeStrategy.java
@@ -1,0 +1,39 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge;
+
+/**
+ *
+ */
+public interface PartialMergeStrategy<P, C, PBT, CtxT extends MergeContext<P, C>>
+    extends MergeStrategy<P, C, PBT, CtxT> {
+
+  public boolean appliesTo(CtxT context);
+
+  /**
+   * {@inheritDoc }
+   * @throws IllegalArgumentException if this strategy does not
+   *                                  {@link #appliesTo(com.torodb.metainfo.cache.mvcc.MergeContext)
+   *                                  apply to}the given context
+   */
+  @Override
+  public ExecutionResult<P> execute(CtxT context, PBT parentBuilder)
+      throws IllegalArgumentException;
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/PojoMergeContext.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/PojoMergeContext.java
@@ -1,0 +1,61 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge;
+
+import com.torodb.core.transaction.metainf.ChangedElement;
+import com.torodb.core.transaction.metainf.MetaElementState;
+
+/**
+ *
+ */
+public class PojoMergeContext<CommitedParentT, ChangedT>
+    implements MergeContext<CommitedParentT, ChangedT> {
+
+  private final CommitedParentT commitedParent;
+  private final ChangedT changed;
+  private final MetaElementState change;
+
+  public PojoMergeContext(CommitedParentT commitedParent, ChangedT changed,
+      MetaElementState change) {
+    this.commitedParent = commitedParent;
+    this.changed = changed;
+    this.change = change;
+  }
+
+  public PojoMergeContext(CommitedParentT commitedParent, 
+      ChangedElement<? extends ChangedT> changed) {
+    this(commitedParent, changed.getElement(), changed.getChange());
+  }
+
+  @Override
+  public CommitedParentT getCommitedParent() {
+    return commitedParent;
+  }
+
+  @Override
+  public ChangedT getChanged() {
+    return changed;
+  }
+
+  @Override
+  public MetaElementState getChange() {
+    return change;
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/SuccessExecutionResult.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/SuccessExecutionResult.java
@@ -1,0 +1,44 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge;
+
+
+import java.util.Optional;
+
+/**
+ *
+ */
+class SuccessExecutionResult<P> extends ExecutionResult<P> {
+
+  static final SuccessExecutionResult<?> INSTANCE = new SuccessExecutionResult<>();
+
+  private SuccessExecutionResult() {
+  }
+
+  @Override
+  public boolean isSuccess() {
+    return true;
+  }
+
+  @Override
+  public Optional<PrettyErrorMessageFactory<P>> getErrorMessageFactory() {
+    return Optional.empty();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/ColContext.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/ColContext.java
@@ -1,0 +1,43 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.collection;
+
+import com.torodb.core.transaction.metainf.ChangedElement;
+import com.torodb.core.transaction.metainf.ImmutableMetaDatabase;
+import com.torodb.core.transaction.metainf.MetaElementState;
+import com.torodb.core.transaction.metainf.MutableMetaCollection;
+import com.torodb.metainfo.cache.mvcc.merge.PojoMergeContext;
+
+/**
+ *
+ */
+public class ColContext
+    extends PojoMergeContext<ImmutableMetaDatabase, MutableMetaCollection> {
+
+  public ColContext(ImmutableMetaDatabase commitedParent, MutableMetaCollection changed,
+      MetaElementState change) {
+    super(commitedParent, changed, change);
+  }
+
+  public ColContext(ImmutableMetaDatabase commitedParent,
+      ChangedElement<? extends MutableMetaCollection> changed) {
+    super(commitedParent, changed);
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/ColContext.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/ColContext.java
@@ -22,13 +22,10 @@ import com.torodb.core.transaction.metainf.ChangedElement;
 import com.torodb.core.transaction.metainf.ImmutableMetaDatabase;
 import com.torodb.core.transaction.metainf.MetaElementState;
 import com.torodb.core.transaction.metainf.MutableMetaCollection;
-import com.torodb.metainfo.cache.mvcc.merge.PojoMergeContext;
+import com.torodb.metainfo.cache.mvcc.merge.DefaultMergeContext;
 
-/**
- *
- */
 public class ColContext
-    extends PojoMergeContext<ImmutableMetaDatabase, MutableMetaCollection> {
+    extends DefaultMergeContext<ImmutableMetaDatabase, MutableMetaCollection> {
 
   public ColContext(ImmutableMetaDatabase commitedParent, MutableMetaCollection changed,
       MetaElementState change) {

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/CollectionMergeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/CollectionMergeStrategy.java
@@ -24,14 +24,14 @@ import com.torodb.core.transaction.metainf.ImmutableMetaDatabase.Builder;
 import com.torodb.core.transaction.metainf.MutableMetaCollection;
 import com.torodb.metainfo.cache.mvcc.merge.ByStateStrategyPicker;
 import com.torodb.metainfo.cache.mvcc.merge.DoNothingMergeStrategy;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
 import com.torodb.metainfo.cache.mvcc.merge.FirstToApplyStrategyPicker;
 import com.torodb.metainfo.cache.mvcc.merge.MergeContext;
 import com.torodb.metainfo.cache.mvcc.merge.MergeStrategy;
 import com.torodb.metainfo.cache.mvcc.merge.MergeStrategyPicker;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
 
 /**
- *
+ * The root strategy used to merge collections.
  */
 @SuppressWarnings("checkstyle:LineLength")
 public class CollectionMergeStrategy implements MergeStrategy<ImmutableMetaDatabase,
@@ -48,15 +48,15 @@ public class CollectionMergeStrategy implements MergeStrategy<ImmutableMetaDatab
   }
 
   @Override
-  public ExecutionResult execute(ColContext context, Builder parentBuilder) {
-    return this.delegate.pick(context)
+  public ExecutionResult<ImmutableMetaDatabase> execute(ColContext context, Builder parentBuilder) {
+    return delegate.pick(context)
         .execute(context, parentBuilder);
   }
 
   private static MergeStrategyPicker<ImmutableMetaDatabase, MutableMetaCollection, Builder, ColContext> createOnAddStrategy() {
     return new FirstToApplyStrategyPicker<>(Lists.newArrayList(
         new SameIdOtherNameStrategy(),
-        new SameNameOtherTypeStrategy(),
+        new SameNameOtherIdStrategy(),
         new NewCollectionStrategy(),
         new ShortcutCollectionStrategy(),
         new ModifiedCollectionChildrenStrategy()
@@ -70,7 +70,7 @@ public class CollectionMergeStrategy implements MergeStrategy<ImmutableMetaDatab
   private static MergeStrategyPicker<ImmutableMetaDatabase, MutableMetaCollection, Builder, ColContext> createOnRemoveStrategy() {
     return new FirstToApplyStrategyPicker<>(Lists.newArrayList(
         new SameIdOtherNameStrategy(),
-        new SameNameOtherTypeStrategy(),
+        new SameNameOtherIdStrategy(),
         new NotExistentCollectionStrategy(),
         new ShortcutCollectionStrategy()
     ), CollectionMergeStrategy::deleteCollection);

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/CollectionMergeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/CollectionMergeStrategy.java
@@ -1,0 +1,85 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.collection;
+
+import com.google.common.collect.Lists;
+import com.torodb.core.transaction.metainf.ImmutableMetaDatabase;
+import com.torodb.core.transaction.metainf.ImmutableMetaDatabase.Builder;
+import com.torodb.core.transaction.metainf.MutableMetaCollection;
+import com.torodb.metainfo.cache.mvcc.merge.ByStateStrategyPicker;
+import com.torodb.metainfo.cache.mvcc.merge.DoNothingMergeStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.FirstToApplyStrategyPicker;
+import com.torodb.metainfo.cache.mvcc.merge.MergeContext;
+import com.torodb.metainfo.cache.mvcc.merge.MergeStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.MergeStrategyPicker;
+
+/**
+ *
+ */
+@SuppressWarnings("checkstyle:LineLength")
+public class CollectionMergeStrategy implements MergeStrategy<ImmutableMetaDatabase,
+    MutableMetaCollection, Builder, ColContext> {
+
+  private final ByStateStrategyPicker<ImmutableMetaDatabase, MutableMetaCollection, Builder, ColContext> delegate;
+
+  public CollectionMergeStrategy() {
+    this.delegate = new ByStateStrategyPicker<>(
+        createOnAddStrategy(),
+        createOnModifyStrategy(),
+        createOnRemoveStrategy()
+    );
+  }
+
+  @Override
+  public ExecutionResult execute(ColContext context, Builder parentBuilder) {
+    return this.delegate.pick(context)
+        .execute(context, parentBuilder);
+  }
+
+  private static MergeStrategyPicker<ImmutableMetaDatabase, MutableMetaCollection, Builder, ColContext> createOnAddStrategy() {
+    return new FirstToApplyStrategyPicker<>(Lists.newArrayList(
+        new SameIdOtherNameStrategy(),
+        new SameNameOtherTypeStrategy(),
+        new NewCollectionStrategy(),
+        new ShortcutCollectionStrategy(),
+        new ModifiedCollectionChildrenStrategy()
+    ), new DoNothingMergeStrategy<>());
+  }
+
+  private static MergeStrategyPicker<ImmutableMetaDatabase, MutableMetaCollection, Builder, ColContext> createOnModifyStrategy() {
+    return createOnAddStrategy();
+  }
+
+  private static MergeStrategyPicker<ImmutableMetaDatabase, MutableMetaCollection, Builder, ColContext> createOnRemoveStrategy() {
+    return new FirstToApplyStrategyPicker<>(Lists.newArrayList(
+        new SameIdOtherNameStrategy(),
+        new SameNameOtherTypeStrategy(),
+        new NotExistentCollectionStrategy(),
+        new ShortcutCollectionStrategy()
+    ), CollectionMergeStrategy::deleteCollection);
+  }
+
+  private static ExecutionResult deleteCollection(
+      MergeContext<ImmutableMetaDatabase, MutableMetaCollection> context, Builder parentBuilder) {
+    parentBuilder.remove(context.getChanged());
+    return ExecutionResult.success();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/CollectionPartialStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/CollectionPartialStrategy.java
@@ -27,7 +27,7 @@ import com.torodb.metainfo.cache.mvcc.merge.PartialMergeStrategy;
 import javax.annotation.Nullable;
 
 /**
- *
+ * A marker interface created to simplify the declaration of collection sub strategies.
  */
 interface CollectionPartialStrategy extends
     PartialMergeStrategy<ImmutableMetaDatabase, MutableMetaCollection, Builder, ColContext> {

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/CollectionPartialStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/CollectionPartialStrategy.java
@@ -1,0 +1,49 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.collection;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
+import com.torodb.core.transaction.metainf.ImmutableMetaDatabase;
+import com.torodb.core.transaction.metainf.ImmutableMetaDatabase.Builder;
+import com.torodb.core.transaction.metainf.MutableMetaCollection;
+import com.torodb.metainfo.cache.mvcc.merge.PartialMergeStrategy;
+
+import javax.annotation.Nullable;
+
+/**
+ *
+ */
+interface CollectionPartialStrategy extends
+    PartialMergeStrategy<ImmutableMetaDatabase, MutableMetaCollection, Builder, ColContext> {
+
+  @Nullable
+  default ImmutableMetaCollection getCommitedById(ColContext context) {
+    return context.getCommitedParent().getMetaCollectionByIdentifier(
+        context.getChanged().getIdentifier()
+    );
+  }
+
+  @Nullable
+  default ImmutableMetaCollection getCommitedByName(ColContext context) {
+    return context.getCommitedParent().getMetaCollectionByName(
+        context.getChanged().getName()
+    );
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/ModifiedCollectionChildrenStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/ModifiedCollectionChildrenStrategy.java
@@ -26,14 +26,18 @@ import com.torodb.core.transaction.metainf.MetaCollection;
 import com.torodb.core.transaction.metainf.MetaElementState;
 import com.torodb.core.transaction.metainf.MutableMetaCollection;
 import com.torodb.metainfo.cache.mvcc.merge.ChildrenMergePartialStrategy;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
 import com.torodb.metainfo.cache.mvcc.merge.docpart.DocPartCtx;
 import com.torodb.metainfo.cache.mvcc.merge.docpart.DocPartMergeStrategy;
 import com.torodb.metainfo.cache.mvcc.merge.index.IndexContext;
 import com.torodb.metainfo.cache.mvcc.merge.index.IndexMergeStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ParentDescriptionFun;
 
 import java.util.stream.Stream;
 
+/**
+ * The strategy that iterates on children elements (doc parts and indexes).
+ */
 class ModifiedCollectionChildrenStrategy
     extends ChildrenMergePartialStrategy<ImmutableMetaDatabase, MutableMetaCollection,
       ImmutableMetaDatabase.Builder, ColContext, Builder, ImmutableMetaCollection>
@@ -81,7 +85,7 @@ class ModifiedCollectionChildrenStrategy
 
   @Override
   protected String describeChanged(
-      ExecutionResult.ParentDescriptionFun<ImmutableMetaDatabase> parentDescFun,
+      ParentDescriptionFun<ImmutableMetaDatabase> parentDescFun,
       ImmutableMetaDatabase parent, ImmutableMetaCollection immutableSelf) {
     return parentDescFun.apply(parent) + '.' + immutableSelf.getIdentifier();
   }

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/ModifiedCollectionChildrenStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/ModifiedCollectionChildrenStrategy.java
@@ -1,0 +1,112 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.collection;
+
+import com.google.common.collect.Streams;
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection.Builder;
+import com.torodb.core.transaction.metainf.ImmutableMetaDatabase;
+import com.torodb.core.transaction.metainf.MetaCollection;
+import com.torodb.core.transaction.metainf.MetaElementState;
+import com.torodb.core.transaction.metainf.MutableMetaCollection;
+import com.torodb.metainfo.cache.mvcc.merge.ChildrenMergePartialStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.docpart.DocPartCtx;
+import com.torodb.metainfo.cache.mvcc.merge.docpart.DocPartMergeStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.index.IndexContext;
+import com.torodb.metainfo.cache.mvcc.merge.index.IndexMergeStrategy;
+
+import java.util.stream.Stream;
+
+class ModifiedCollectionChildrenStrategy
+    extends ChildrenMergePartialStrategy<ImmutableMetaDatabase, MutableMetaCollection,
+      ImmutableMetaDatabase.Builder, ColContext, Builder, ImmutableMetaCollection>
+    implements CollectionPartialStrategy {
+
+  private final DocPartMergeStrategy docPartStrategy = new DocPartMergeStrategy();
+  private final IndexMergeStrategy indexStrategy = new IndexMergeStrategy();
+
+  @Override
+  public boolean appliesTo(ColContext context) {
+    switch (context.getChange()) {
+      case ADDED:
+      case MODIFIED:
+        break;
+      default:
+        return false;
+    }
+
+    MetaCollection byId = getCommitedById(context);
+    MetaCollection byName = getCommitedByName(context);
+
+    return byId != null && byId == byName;
+  }
+
+  @Override
+  protected Builder createSelfBuilder(ColContext context) {
+    MetaCollection byId = getCommitedById(context);
+    assert byId != null;
+    return new Builder(byId.immutableCopy());
+  }
+
+  @Override
+  protected Stream<ExecutionResult<ImmutableMetaCollection>> streamChildResults(
+      ColContext context, Builder selfBuilder) {
+    return Streams.concat(
+        streamDocPartResults(context, selfBuilder),
+        streamIndexResults(context, selfBuilder)
+    );
+  }
+  
+  @Override
+  protected void changeParent(ImmutableMetaDatabase.Builder parentBuilder, Builder selfBuilder) {
+    parentBuilder.put(selfBuilder);
+  }
+
+  @Override
+  protected String describeChanged(
+      ExecutionResult.ParentDescriptionFun<ImmutableMetaDatabase> parentDescFun,
+      ImmutableMetaDatabase parent, ImmutableMetaCollection immutableSelf) {
+    return parentDescFun.apply(parent) + '.' + immutableSelf.getIdentifier();
+  }
+
+  private Stream<ExecutionResult<ImmutableMetaCollection>> streamDocPartResults(
+      ColContext context, Builder selfBuilder) {
+    return context.getChanged().streamModifiedMetaDocParts()
+        .map(change -> new DocPartCtx(
+            getCommitedById(context),
+            change,
+            MetaElementState.ADDED,
+            context.getChanged())
+        )
+        .map(childContext -> docPartStrategy.execute(childContext, selfBuilder));
+  }
+
+  private Stream<ExecutionResult<ImmutableMetaCollection>> streamIndexResults(
+      ColContext context, Builder selfBuilder) {
+    return context.getChanged().streamModifiedMetaIndexes()
+        .map(change -> new IndexContext(
+            getCommitedById(context),
+            change,
+            context.getChanged()
+        ))
+        .map(childContext -> indexStrategy.execute(childContext, selfBuilder));
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/NewCollectionStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/NewCollectionStrategy.java
@@ -1,0 +1,46 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.collection;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaDatabase;
+import com.torodb.core.transaction.metainf.ImmutableMetaDatabase.Builder;
+import com.torodb.core.transaction.metainf.MetaElementState;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+
+/**
+ *
+ */
+class NewCollectionStrategy implements CollectionPartialStrategy {
+
+  @Override
+  public boolean appliesTo(ColContext context) {
+    MetaElementState change = context.getChange();
+    if (change != MetaElementState.ADDED && change != MetaElementState.MODIFIED) {
+      return false;
+    }
+    return getCommitedById(context) == null && getCommitedByName(context) == null;
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaDatabase> execute(ColContext context, Builder parentBuilder) {
+    parentBuilder.put(context.getChanged().immutableCopy());
+    return ExecutionResult.success();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/NewCollectionStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/NewCollectionStrategy.java
@@ -21,10 +21,10 @@ package com.torodb.metainfo.cache.mvcc.merge.collection;
 import com.torodb.core.transaction.metainf.ImmutableMetaDatabase;
 import com.torodb.core.transaction.metainf.ImmutableMetaDatabase.Builder;
 import com.torodb.core.transaction.metainf.MetaElementState;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
 
 /**
- *
+ * The strategy used when there is no commited collection with the same name and identifier.
  */
 class NewCollectionStrategy implements CollectionPartialStrategy {
 

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/NotExistentCollectionStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/NotExistentCollectionStrategy.java
@@ -21,7 +21,7 @@ package com.torodb.metainfo.cache.mvcc.merge.collection;
 import com.torodb.core.transaction.metainf.ImmutableMetaDatabase;
 import com.torodb.core.transaction.metainf.ImmutableMetaDatabase.Builder;
 import com.torodb.core.transaction.metainf.MetaElementState;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
 
 /**
  * A partial strategy that applies when a collection is being removed but it is not found on the

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/NotExistentCollectionStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/NotExistentCollectionStrategy.java
@@ -1,0 +1,51 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.collection;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaDatabase;
+import com.torodb.core.transaction.metainf.ImmutableMetaDatabase.Builder;
+import com.torodb.core.transaction.metainf.MetaElementState;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+
+/**
+ * A partial strategy that applies when a collection is being removed but it is not found on the
+ * commited database.
+ *
+ * <p/>This can happen when a collection is created and removed on the same transaction or when
+ * merging a transaction that removes a collection that has been already removed by a concurrent
+ * transaction that has been commited after this one is created but before it is commited.
+ */
+class NotExistentCollectionStrategy implements CollectionPartialStrategy {
+
+  @Override
+  public boolean appliesTo(ColContext context) {
+    MetaElementState change = context.getChange();
+    if (change != MetaElementState.REMOVED) {
+      return false;
+    }
+    return getCommitedById(context) == null && getCommitedByName(context) == null;
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaDatabase> execute(ColContext context,
+      Builder parentBuilder) throws IllegalArgumentException {
+    return ExecutionResult.success();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/SameIdOtherNameStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/SameIdOtherNameStrategy.java
@@ -21,12 +21,11 @@ package com.torodb.metainfo.cache.mvcc.merge.collection;
 import com.torodb.core.transaction.metainf.ImmutableMetaDatabase;
 import com.torodb.core.transaction.metainf.ImmutableMetaDatabase.Builder;
 import com.torodb.core.transaction.metainf.MetaCollection;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
-
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ParentDescriptionFun;
 
 /**
- *
+ * Checks whether there is a commited collection with the same id but different name.
  */
 class SameIdOtherNameStrategy implements CollectionPartialStrategy {
 

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/SameIdOtherNameStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/SameIdOtherNameStrategy.java
@@ -1,0 +1,63 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.collection;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaDatabase;
+import com.torodb.core.transaction.metainf.ImmutableMetaDatabase.Builder;
+import com.torodb.core.transaction.metainf.MetaCollection;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+
+
+/**
+ *
+ */
+class SameIdOtherNameStrategy implements CollectionPartialStrategy {
+
+  @Override
+  public boolean appliesTo(ColContext context) {
+    MetaCollection byId = getCommitedById(context);
+    return byId != null && !byId.getName().equals(context.getChanged().getName());
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaDatabase> execute(
+      ColContext context,
+      Builder parentBuilder) throws IllegalArgumentException {
+    return ExecutionResult.error(
+        getClass(),
+        parentDescFun -> getErrorMessage(context, parentDescFun)
+    );
+  }
+
+  private String getErrorMessage(ColContext context, 
+      ParentDescriptionFun<ImmutableMetaDatabase> parentDescription) {
+    MetaCollection changed = context.getChanged();
+    MetaCollection byId = getCommitedById(context);
+    assert byId != null;
+    String parent = parentDescription.apply(context.getCommitedParent());
+    String describeChange = context.getChange().toString();
+
+    return "The modified meta collection " + parent + '.' + changed.getIdentifier() + " with name "
+        + changed.getName() + " cannot be " + describeChange + " because there is an already "
+        + "commited collection identified as " + byId.getIdentifier() + " whose name is "
+        + byId.getName();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/SameNameOtherIdStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/SameNameOtherIdStrategy.java
@@ -21,14 +21,14 @@ package com.torodb.metainfo.cache.mvcc.merge.collection;
 import com.torodb.core.transaction.metainf.ImmutableMetaDatabase;
 import com.torodb.core.transaction.metainf.ImmutableMetaDatabase.Builder;
 import com.torodb.core.transaction.metainf.MetaCollection;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ParentDescriptionFun;
 
 
 /**
- *
+ * Checks whether there is another collection with the same name but different id.
  */
-class SameNameOtherTypeStrategy implements CollectionPartialStrategy {
+class SameNameOtherIdStrategy implements CollectionPartialStrategy {
 
   @Override
   public boolean appliesTo(ColContext context) {

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/SameNameOtherTypeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/SameNameOtherTypeStrategy.java
@@ -1,0 +1,62 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.collection;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaDatabase;
+import com.torodb.core.transaction.metainf.ImmutableMetaDatabase.Builder;
+import com.torodb.core.transaction.metainf.MetaCollection;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+
+
+/**
+ *
+ */
+class SameNameOtherTypeStrategy implements CollectionPartialStrategy {
+
+  @Override
+  public boolean appliesTo(ColContext context) {
+    MetaCollection changed = context.getChanged();
+    MetaCollection byName = getCommitedByName(context);
+    return byName != null && !byName.getIdentifier().equals(changed.getIdentifier());
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaDatabase> execute(ColContext context, Builder callback) {
+    return ExecutionResult.error(
+        getClass(),
+        parentDescFun -> getErrorMessage(parentDescFun, context)
+    );
+  }
+
+  private String getErrorMessage(
+      ParentDescriptionFun<ImmutableMetaDatabase> parentDescFun,
+      ColContext context) {
+    MetaCollection changed = context.getChanged();
+    MetaCollection byName = getCommitedByName(context);
+    assert byName != null;
+    String parent = parentDescFun.apply(context.getCommitedParent());
+    String describeChange = context.getChange().toString();
+
+    return "The meta collection " + parent + '.' + changed.getIdentifier() + " with name "
+        + changed.getName() + " cannot be " + describeChange + " because there is an already "
+        + "commited collection identified as " + byName.getIdentifier() + " with the same name";
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/ShortcutCollectionStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/ShortcutCollectionStrategy.java
@@ -1,0 +1,58 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.collection;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
+import com.torodb.core.transaction.metainf.ImmutableMetaDatabase;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+
+/**
+ *
+ */
+public class ShortcutCollectionStrategy implements CollectionPartialStrategy {
+
+  @Override
+  public boolean appliesTo(ColContext context) {
+    ImmutableMetaCollection origin = context.getChanged().getOrigin();
+    ImmutableMetaCollection commited = context.getCommitedParent().getMetaCollectionByName(
+        origin.getName()
+    );
+
+    return commited != null && commited == origin;
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaDatabase> execute(ColContext context,
+      ImmutableMetaDatabase.Builder parentBuilder) throws IllegalArgumentException {
+    switch (context.getChange()) {
+      case ADDED:
+      case MODIFIED:
+        parentBuilder.put(context.getChanged().immutableCopy());
+        break;
+      case REMOVED:
+        parentBuilder.remove(context.getChanged());
+        break;
+      default:
+        throw new AssertionError("Unexpected change " + context.getChange());
+    }
+
+    return ExecutionResult.success();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/ShortcutCollectionStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/collection/ShortcutCollectionStrategy.java
@@ -20,10 +20,14 @@ package com.torodb.metainfo.cache.mvcc.merge.collection;
 
 import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
 import com.torodb.core.transaction.metainf.ImmutableMetaDatabase;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.core.transaction.metainf.MutableMetaCollection;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
 
 /**
- *
+ * A strategy that shortcuts the merge process if the commited collection is the same as the
+ * {@link MutableMetaCollection#getOrigin() origin} of the one that is being merged, which means
+ * that no other transaction modified the commited collection and therefore no more checks need
+ * to be done.
  */
 public class ShortcutCollectionStrategy implements CollectionPartialStrategy {
 

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/DatabaseMergeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/DatabaseMergeStrategy.java
@@ -24,13 +24,13 @@ import com.torodb.core.transaction.metainf.ImmutableMetaSnapshot.Builder;
 import com.torodb.core.transaction.metainf.MutableMetaDatabase;
 import com.torodb.metainfo.cache.mvcc.merge.ByStateStrategyPicker;
 import com.torodb.metainfo.cache.mvcc.merge.DoNothingMergeStrategy;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
 import com.torodb.metainfo.cache.mvcc.merge.FirstToApplyStrategyPicker;
 import com.torodb.metainfo.cache.mvcc.merge.MergeStrategy;
 import com.torodb.metainfo.cache.mvcc.merge.MergeStrategyPicker;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
 
 /**
- *
+ * The root strategy used to merge databases.
  */
 @SuppressWarnings("checkstyle:LineLength")
 public class DatabaseMergeStrategy

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/DatabaseMergeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/DatabaseMergeStrategy.java
@@ -1,0 +1,85 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.db;
+
+import com.google.common.collect.Lists;
+import com.torodb.core.transaction.metainf.ImmutableMetaSnapshot;
+import com.torodb.core.transaction.metainf.ImmutableMetaSnapshot.Builder;
+import com.torodb.core.transaction.metainf.MutableMetaDatabase;
+import com.torodb.metainfo.cache.mvcc.merge.ByStateStrategyPicker;
+import com.torodb.metainfo.cache.mvcc.merge.DoNothingMergeStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.FirstToApplyStrategyPicker;
+import com.torodb.metainfo.cache.mvcc.merge.MergeStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.MergeStrategyPicker;
+
+/**
+ *
+ */
+@SuppressWarnings("checkstyle:LineLength")
+public class DatabaseMergeStrategy
+    implements MergeStrategy<ImmutableMetaSnapshot, MutableMetaDatabase, Builder, DbContext> {
+
+  private final ByStateStrategyPicker<ImmutableMetaSnapshot, MutableMetaDatabase, Builder, DbContext> delegate;
+
+  public DatabaseMergeStrategy() {
+    this.delegate = new ByStateStrategyPicker<>(
+        createOnAddStrategy(),
+        createOnModifyStrategy(),
+        createOnRemoveStrategy()
+    );
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaSnapshot> execute(DbContext context, Builder parentBuilder) {
+    return delegate.pick(context)
+        .execute(context, parentBuilder);
+  }
+
+  private static MergeStrategyPicker<ImmutableMetaSnapshot, MutableMetaDatabase, Builder, DbContext> createOnAddStrategy() {
+    return new FirstToApplyStrategyPicker<>(Lists.newArrayList(
+        new SameIdOtherNameStrategy(),
+        new SameNameOtherTypeStrategy(),
+        new NewDatabaseStrategy(),
+        new ShortcutDatabaseStrategy(),
+        new ModifiedDatabaseChildrenStrategy()
+    ), new DoNothingMergeStrategy<>());
+  }
+
+  private static MergeStrategyPicker<ImmutableMetaSnapshot, MutableMetaDatabase, Builder, DbContext> createOnModifyStrategy() {
+    return createOnAddStrategy();
+  }
+
+  private static MergeStrategyPicker<ImmutableMetaSnapshot, MutableMetaDatabase, Builder, DbContext> createOnRemoveStrategy() {
+    return new FirstToApplyStrategyPicker<>(Lists.newArrayList(
+        new SameIdOtherNameStrategy(),
+        new SameNameOtherTypeStrategy(),
+        new ShortcutDatabaseStrategy(),
+        new NotExistentDatabaseStrategy()
+    ), DatabaseMergeStrategy::deleteDatabase);
+  }
+
+  private static ExecutionResult<ImmutableMetaSnapshot> deleteDatabase(
+      DbContext context,
+      Builder parentBuilder) {
+    parentBuilder.remove(context.getChanged());
+    return ExecutionResult.success();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/DatabasePartialStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/DatabasePartialStrategy.java
@@ -28,7 +28,7 @@ import javax.annotation.Nullable;
 
 
 /**
- *
+ * A marker interface created to simplify the declaration of collection sub strategies.
  */
 interface DatabasePartialStrategy extends
     PartialMergeStrategy<ImmutableMetaSnapshot, MutableMetaDatabase, Builder, DbContext> {

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/DatabasePartialStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/DatabasePartialStrategy.java
@@ -1,0 +1,49 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.db;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaDatabase;
+import com.torodb.core.transaction.metainf.ImmutableMetaSnapshot;
+import com.torodb.core.transaction.metainf.ImmutableMetaSnapshot.Builder;
+import com.torodb.core.transaction.metainf.MutableMetaDatabase;
+import com.torodb.metainfo.cache.mvcc.merge.PartialMergeStrategy;
+
+import javax.annotation.Nullable;
+
+
+/**
+ *
+ */
+interface DatabasePartialStrategy extends
+    PartialMergeStrategy<ImmutableMetaSnapshot, MutableMetaDatabase, Builder, DbContext> {
+
+  @Nullable
+  default ImmutableMetaDatabase getCommitedById(DbContext context) {
+    return context.getCommitedParent()
+        .getMetaDatabaseByIdentifier(context.getChanged().getIdentifier());
+  }
+
+  @Nullable
+  default ImmutableMetaDatabase getCommitedByName(DbContext context) {
+    return context.getCommitedParent().getMetaDatabaseByName(
+        context.getChanged().getName()
+    );
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/DbContext.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/DbContext.java
@@ -21,12 +21,9 @@ package com.torodb.metainfo.cache.mvcc.merge.db;
 import com.torodb.core.transaction.metainf.ChangedElement;
 import com.torodb.core.transaction.metainf.ImmutableMetaSnapshot;
 import com.torodb.core.transaction.metainf.MutableMetaDatabase;
-import com.torodb.metainfo.cache.mvcc.merge.PojoMergeContext;
+import com.torodb.metainfo.cache.mvcc.merge.DefaultMergeContext;
 
-/**
- *
- */
-public class DbContext extends PojoMergeContext<ImmutableMetaSnapshot, MutableMetaDatabase> {
+public class DbContext extends DefaultMergeContext<ImmutableMetaSnapshot, MutableMetaDatabase> {
 
   public DbContext(ImmutableMetaSnapshot commitedParent,
       ChangedElement<? extends MutableMetaDatabase> changed) {

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/DbContext.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/DbContext.java
@@ -1,0 +1,35 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.db;
+
+import com.torodb.core.transaction.metainf.ChangedElement;
+import com.torodb.core.transaction.metainf.ImmutableMetaSnapshot;
+import com.torodb.core.transaction.metainf.MutableMetaDatabase;
+import com.torodb.metainfo.cache.mvcc.merge.PojoMergeContext;
+
+/**
+ *
+ */
+public class DbContext extends PojoMergeContext<ImmutableMetaSnapshot, MutableMetaDatabase> {
+
+  public DbContext(ImmutableMetaSnapshot commitedParent,
+      ChangedElement<? extends MutableMetaDatabase> changed) {
+    super(commitedParent, changed);
+  }
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/ModifiedDatabaseChildrenStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/ModifiedDatabaseChildrenStrategy.java
@@ -1,0 +1,86 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.db;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaDatabase;
+import com.torodb.core.transaction.metainf.ImmutableMetaDatabase.Builder;
+import com.torodb.core.transaction.metainf.ImmutableMetaSnapshot;
+import com.torodb.core.transaction.metainf.MetaDatabase;
+import com.torodb.core.transaction.metainf.MutableMetaDatabase;
+import com.torodb.metainfo.cache.mvcc.merge.ChildrenMergePartialStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.collection.ColContext;
+import com.torodb.metainfo.cache.mvcc.merge.collection.CollectionMergeStrategy;
+
+import java.util.stream.Stream;
+
+
+
+class ModifiedDatabaseChildrenStrategy extends ChildrenMergePartialStrategy<ImmutableMetaSnapshot,
+    MutableMetaDatabase, ImmutableMetaSnapshot.Builder, DbContext, Builder, ImmutableMetaDatabase>
+    implements DatabasePartialStrategy {
+
+  private final CollectionMergeStrategy collectionStrategy = new CollectionMergeStrategy();
+
+  @Override
+  public boolean appliesTo(DbContext context) {
+    switch (context.getChange()) {
+      case ADDED:
+      case MODIFIED:
+        break;
+      default:
+        return false;
+    }
+
+    MetaDatabase byId = getCommitedById(context);
+    MetaDatabase byName = getCommitedByName(context);
+
+    return byId != null && byId == byName;
+  }
+
+  @Override
+  protected Builder createSelfBuilder(DbContext context) {
+    MetaDatabase byId = getCommitedById(context);
+    assert byId != null;
+    return new Builder(byId.immutableCopy());
+  }
+
+  @Override
+  protected Stream<ExecutionResult<ImmutableMetaDatabase>> streamChildResults(
+      DbContext context, Builder selfBuilder) {
+    ImmutableMetaDatabase oldVersion = getCommitedById(context);
+    return context.getChanged().streamModifiedCollections()
+        .map(change -> new ColContext(oldVersion, change))
+        .map(ctx -> collectionStrategy.execute(ctx, selfBuilder));
+  }
+  
+  @Override
+  protected void changeParent(ImmutableMetaSnapshot.Builder parentBuilder, Builder selfBuilder) {
+    parentBuilder.put(selfBuilder);
+  }
+
+  @Override
+  protected String describeChanged(
+      ExecutionResult.ParentDescriptionFun<ImmutableMetaSnapshot> parentDescFun,
+      ImmutableMetaSnapshot parent, ImmutableMetaDatabase immutableSelf) {
+    return immutableSelf.getIdentifier();
+  }
+
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/ModifiedDatabaseChildrenStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/ModifiedDatabaseChildrenStrategy.java
@@ -24,14 +24,16 @@ import com.torodb.core.transaction.metainf.ImmutableMetaSnapshot;
 import com.torodb.core.transaction.metainf.MetaDatabase;
 import com.torodb.core.transaction.metainf.MutableMetaDatabase;
 import com.torodb.metainfo.cache.mvcc.merge.ChildrenMergePartialStrategy;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
 import com.torodb.metainfo.cache.mvcc.merge.collection.ColContext;
 import com.torodb.metainfo.cache.mvcc.merge.collection.CollectionMergeStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ParentDescriptionFun;
 
 import java.util.stream.Stream;
 
-
-
+/**
+ * The strategy that iterates on children elements (collections).
+ */
 class ModifiedDatabaseChildrenStrategy extends ChildrenMergePartialStrategy<ImmutableMetaSnapshot,
     MutableMetaDatabase, ImmutableMetaSnapshot.Builder, DbContext, Builder, ImmutableMetaDatabase>
     implements DatabasePartialStrategy {
@@ -77,7 +79,7 @@ class ModifiedDatabaseChildrenStrategy extends ChildrenMergePartialStrategy<Immu
 
   @Override
   protected String describeChanged(
-      ExecutionResult.ParentDescriptionFun<ImmutableMetaSnapshot> parentDescFun,
+      ParentDescriptionFun<ImmutableMetaSnapshot> parentDescFun,
       ImmutableMetaSnapshot parent, ImmutableMetaDatabase immutableSelf) {
     return immutableSelf.getIdentifier();
   }

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/NewDatabaseStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/NewDatabaseStrategy.java
@@ -1,0 +1,46 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.db;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaSnapshot;
+import com.torodb.core.transaction.metainf.MetaElementState;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+
+/**
+ *
+ */
+class NewDatabaseStrategy implements DatabasePartialStrategy {
+
+  @Override
+  public boolean appliesTo(DbContext context) {
+    MetaElementState change = context.getChange();
+    if (change != MetaElementState.ADDED && change != MetaElementState.MODIFIED) {
+      return false;
+    }
+    return getCommitedById(context) == null && getCommitedByName(context) == null;
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaSnapshot> execute(DbContext context,
+      ImmutableMetaSnapshot.Builder parentBuilder) throws IllegalArgumentException {
+    parentBuilder.put(context.getChanged().immutableCopy());
+    return ExecutionResult.success();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/NewDatabaseStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/NewDatabaseStrategy.java
@@ -20,10 +20,10 @@ package com.torodb.metainfo.cache.mvcc.merge.db;
 
 import com.torodb.core.transaction.metainf.ImmutableMetaSnapshot;
 import com.torodb.core.transaction.metainf.MetaElementState;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
 
 /**
- *
+ * The strategy used when there is no commited database with the same name and identifier.
  */
 class NewDatabaseStrategy implements DatabasePartialStrategy {
 

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/NotExistentDatabaseStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/NotExistentDatabaseStrategy.java
@@ -1,0 +1,52 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.db;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaSnapshot;
+import com.torodb.core.transaction.metainf.ImmutableMetaSnapshot.Builder;
+import com.torodb.core.transaction.metainf.MetaElementState;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+
+
+/**
+ * A partial strategy that applies when a database is being removed but it is not found on the
+ * commited snapshot.
+ *
+ * <p/>This can happen when a database is created and removed on the same transaction or when
+ * merging a transaction that removes a database that has been already removed by a concurrent
+ * transaction that has been commited after this one is created but before it is commited.
+ */
+class NotExistentDatabaseStrategy implements DatabasePartialStrategy {
+
+  @Override
+  public boolean appliesTo(DbContext context) {
+    MetaElementState change = context.getChange();
+    if (change != MetaElementState.REMOVED) {
+      return false;
+    }
+    return getCommitedById(context) == null && getCommitedByName(context) == null;
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaSnapshot> execute(DbContext context, Builder parentBuilder)
+      throws IllegalArgumentException {
+    return ExecutionResult.success();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/NotExistentDatabaseStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/NotExistentDatabaseStrategy.java
@@ -21,7 +21,7 @@ package com.torodb.metainfo.cache.mvcc.merge.db;
 import com.torodb.core.transaction.metainf.ImmutableMetaSnapshot;
 import com.torodb.core.transaction.metainf.ImmutableMetaSnapshot.Builder;
 import com.torodb.core.transaction.metainf.MetaElementState;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
 
 
 /**

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/SameIdOtherNameStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/SameIdOtherNameStrategy.java
@@ -1,0 +1,62 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.db;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaSnapshot;
+import com.torodb.core.transaction.metainf.ImmutableMetaSnapshot.Builder;
+import com.torodb.core.transaction.metainf.MetaDatabase;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+
+
+/**
+ *
+ */
+class SameIdOtherNameStrategy implements DatabasePartialStrategy {
+
+  @Override
+  public boolean appliesTo(DbContext context) {
+    MetaDatabase byId = getCommitedById(context);
+    return byId != null && !byId.getName().equals(context.getChanged().getName());
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaSnapshot> execute(DbContext context, Builder parentBuilder)
+      throws IllegalArgumentException {
+    return ExecutionResult.error(
+        getClass(),
+        parentDescFun -> getErrorMessage(context, parentDescFun)
+    );
+  }
+
+  private String getErrorMessage(DbContext context,
+      ParentDescriptionFun<ImmutableMetaSnapshot> parentDescription) {
+    MetaDatabase changed = context.getChanged();
+    MetaDatabase byId = getCommitedById(context);
+    assert byId != null;
+    String parent = parentDescription.apply(context.getCommitedParent());
+    String describeChange = context.getChange().toString();
+
+    return "The modified meta database " + parent + '.' + changed.getIdentifier() + " with name "
+        + changed.getName() + " cannot be " + describeChange + " because there is an already "
+        + "commited database identified as " + byId.getIdentifier() + " whose name is "
+        + byId.getName();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/SameIdOtherNameStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/SameIdOtherNameStrategy.java
@@ -21,12 +21,11 @@ package com.torodb.metainfo.cache.mvcc.merge.db;
 import com.torodb.core.transaction.metainf.ImmutableMetaSnapshot;
 import com.torodb.core.transaction.metainf.ImmutableMetaSnapshot.Builder;
 import com.torodb.core.transaction.metainf.MetaDatabase;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
-
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ParentDescriptionFun;
 
 /**
- *
+ * Checks whether there is a commited database with the same id but different name.
  */
 class SameIdOtherNameStrategy implements DatabasePartialStrategy {
 

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/SameNameOtherTypeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/SameNameOtherTypeStrategy.java
@@ -1,0 +1,64 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.db;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaSnapshot;
+import com.torodb.core.transaction.metainf.MetaDatabase;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+
+
+/**
+ *
+ */
+class SameNameOtherTypeStrategy implements DatabasePartialStrategy {
+
+  @Override
+  public boolean appliesTo(DbContext context) {
+    MetaDatabase changed = context.getChanged();
+    MetaDatabase byName = getCommitedByName(context);
+    return byName != null && !byName.getIdentifier().equals(changed.getIdentifier());
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaSnapshot> execute(
+      DbContext context,
+      ImmutableMetaSnapshot.Builder callback)
+      throws IllegalArgumentException {
+    return ExecutionResult.error(
+        getClass(),
+        parentDescFun -> getErrorMessage(parentDescFun, context)
+    );
+  }
+
+  private String getErrorMessage(
+      ParentDescriptionFun<ImmutableMetaSnapshot> parentDescFun,
+      DbContext context) {
+    MetaDatabase changed = context.getChanged();
+    MetaDatabase byName = getCommitedByName(context);
+    assert byName != null;
+    String parent = parentDescFun.apply(context.getCommitedParent());
+    String describeChange = context.getChange().toString();
+
+    return "The meta database " + parent + '.' + changed.getIdentifier() + " with name "
+        + changed.getName() + " cannot be " + describeChange + " because there is an already "
+        + "commited database identified as " + byName.getIdentifier() + " with the same name";
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/SameNameOtherTypeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/SameNameOtherTypeStrategy.java
@@ -20,12 +20,12 @@ package com.torodb.metainfo.cache.mvcc.merge.db;
 
 import com.torodb.core.transaction.metainf.ImmutableMetaSnapshot;
 import com.torodb.core.transaction.metainf.MetaDatabase;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ParentDescriptionFun;
 
 
 /**
- *
+ * Checks whether there is a commited database with the same name but different id.
  */
 class SameNameOtherTypeStrategy implements DatabasePartialStrategy {
 

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/ShortcutDatabaseStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/ShortcutDatabaseStrategy.java
@@ -1,0 +1,58 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.db;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaDatabase;
+import com.torodb.core.transaction.metainf.ImmutableMetaSnapshot;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+
+/**
+ *
+ */
+public class ShortcutDatabaseStrategy implements DatabasePartialStrategy {
+
+  @Override
+  public boolean appliesTo(DbContext context) {
+    ImmutableMetaDatabase origin = context.getChanged().getOrigin();
+    ImmutableMetaDatabase commited = context.getCommitedParent()
+        .getMetaDatabaseByName(origin.getName());
+
+    return commited != null && commited == origin;
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaSnapshot> execute(DbContext context,
+      ImmutableMetaSnapshot.Builder parentBuilder) throws IllegalArgumentException {
+
+    switch (context.getChange()) {
+      case ADDED:
+      case MODIFIED:
+        parentBuilder.put(context.getChanged().immutableCopy());
+        break;
+      case REMOVED:
+        parentBuilder.remove(context.getChanged());
+        break;
+      default:
+        throw new AssertionError("Unexpected change " + context.getChange());
+    }
+
+    return ExecutionResult.success();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/ShortcutDatabaseStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/db/ShortcutDatabaseStrategy.java
@@ -20,10 +20,14 @@ package com.torodb.metainfo.cache.mvcc.merge.db;
 
 import com.torodb.core.transaction.metainf.ImmutableMetaDatabase;
 import com.torodb.core.transaction.metainf.ImmutableMetaSnapshot;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.core.transaction.metainf.MutableMetaDatabase;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
 
 /**
- *
+ * A strategy that shortcuts the merge process if the commited database is the same as the
+ * {@link MutableMetaDatabase#getOrigin() origin} of the one that is being merged, which means
+ * that no other transaction modified the commited database and therefore no more checks need
+ * to be done.
  */
 public class ShortcutDatabaseStrategy implements DatabasePartialStrategy {
 

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpart/DocPartChildrenStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpart/DocPartChildrenStrategy.java
@@ -1,0 +1,183 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.docpart;
+
+import com.google.common.collect.Streams;
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart.Builder;
+import com.torodb.core.transaction.metainf.MetaCollection;
+import com.torodb.core.transaction.metainf.MetaDocPart;
+import com.torodb.core.transaction.metainf.MetaElementState;
+import com.torodb.core.transaction.metainf.MutableMetaCollection;
+import com.torodb.core.transaction.metainf.MutableMetaDocPart;
+import com.torodb.metainfo.cache.mvcc.merge.ChildrenMergePartialStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.InnerErrorMessageFactory;
+import com.torodb.metainfo.cache.mvcc.merge.MergeContext;
+import com.torodb.metainfo.cache.mvcc.merge.docpartindex.DocPartIndexCtx;
+import com.torodb.metainfo.cache.mvcc.merge.docpartindex.DocPartIndexMergeStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.field.FieldContext;
+import com.torodb.metainfo.cache.mvcc.merge.field.FieldMergeStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.scalar.ScalarContext;
+import com.torodb.metainfo.cache.mvcc.merge.scalar.ScalarMergeStrategy;
+
+import java.util.stream.Stream;
+
+
+/**
+ *
+ */
+public class DocPartChildrenStrategy
+    extends ChildrenMergePartialStrategy<ImmutableMetaCollection, MutableMetaDocPart,
+    ImmutableMetaCollection.Builder, DocPartCtx, Builder, ImmutableMetaDocPart>
+    implements DocPartPartialStrategy {
+
+  private final ScalarMergeStrategy scalarStrategy = new ScalarMergeStrategy();
+  private final FieldMergeStrategy fieldStrategy = new FieldMergeStrategy();
+  private final DocPartIndexMergeStrategy indexStrategy = new DocPartIndexMergeStrategy();
+
+  @Override
+  public boolean appliesTo(DocPartCtx context) {
+    switch (context.getChange()) {
+      case ADDED:
+      case MODIFIED:
+        break;
+      default:
+        return false;
+    }
+
+    MetaDocPart byId = getCommitedById(context);
+    MetaDocPart byRef = getCommitedByTableRef(context);
+
+    return byId != null && byId == byRef;
+  }
+
+  @Override
+  protected Builder createSelfBuilder(DocPartCtx context) {
+    MetaDocPart byId = getCommitedById(context);
+    assert byId != null;
+    return new Builder(byId.immutableCopy());
+  }
+
+  @Override
+  protected Stream<ExecutionResult<ImmutableMetaDocPart>> streamChildResults(
+      DocPartCtx context,
+      Builder selfBuilder) {
+    MutableMetaDocPart changed = context.getChanged();
+    ImmutableMetaDocPart oldVersion = getCommitedById(context);
+    ImmutableMetaCollection cmtParent = context.getCommitedParent();
+    MutableMetaCollection uncmtParent = context.getUncommitedParent();
+    return Streams.concat(
+        streamScalarRecursiveErrors(oldVersion, changed, selfBuilder),
+        streamFieldRecursiveErrors(oldVersion, changed, selfBuilder, cmtParent, uncmtParent),
+        streamIndexRecursiveErrors(oldVersion, context, selfBuilder)
+    );
+  }
+
+  @Override
+  protected void changeParent(ImmutableMetaCollection.Builder parentBuilder, Builder selfBuilder) {
+    parentBuilder.put(selfBuilder);
+  }
+
+  @Override
+  protected String describeChanged(
+      ExecutionResult.ParentDescriptionFun<ImmutableMetaCollection> parentDescFun,
+      ImmutableMetaCollection parent, ImmutableMetaDocPart immutableSelf) {
+    return parentDescFun.apply(parent) + '.' + immutableSelf.getIdentifier();
+  }
+
+  private Stream<ExecutionResult<ImmutableMetaDocPart>> streamScalarRecursiveErrors(
+      ImmutableMetaDocPart oldVersion,
+      MutableMetaDocPart changed,
+      Builder newDocPartBuilder) {
+
+    return changed.streamAddedMetaScalars()
+        .map(scalar -> new ScalarContext(oldVersion, scalar, MetaElementState.ADDED))
+        .map(ctx -> scalarStrategy.execute(ctx, newDocPartBuilder));
+  }
+
+  private Stream<ExecutionResult<ImmutableMetaDocPart>> streamFieldRecursiveErrors(
+      ImmutableMetaDocPart oldVersion,
+      MutableMetaDocPart changed,
+      Builder newDocPartBuilder,
+      ImmutableMetaCollection commitedParent,
+      MutableMetaCollection uncommitedParent) {
+
+    return changed.streamAddedMetaFields()
+        .map(field -> new FieldContext(
+            oldVersion,
+            field,
+            changed,
+            commitedParent,
+            uncommitedParent)
+        )
+        .map(ctx -> fieldStrategy.execute(ctx, newDocPartBuilder));
+  }
+
+  private Stream<ExecutionResult<ImmutableMetaDocPart>> streamIndexRecursiveErrors(
+      ImmutableMetaDocPart oldVersion,
+      DocPartCtx context,
+      Builder newDocPartBuilder) {
+    return context.getChanged().streamModifiedMetaDocPartIndexes()
+        .map(change -> new DocPartIndexCtx(
+            oldVersion, 
+            change, 
+            context.getChanged(), 
+            context.getCommitedParent(), 
+            context.getUncommitedParent())
+        )
+        .map(ctx -> indexStrategy.execute(ctx, newDocPartBuilder));
+  }
+
+
+  /**
+   * Given a context and a stream with the result of the sub structures, returns a single
+   * {@link ExecutionResult} that describes the first error it found or a
+   * {@link ExecutionResult#success() success} if there is no error.
+   */
+  private <S> ExecutionResult<MetaCollection> mergeSubStructure(
+      MergeContext<MetaCollection, MutableMetaDocPart> context,
+      Stream<ExecutionResult<MetaDocPart>> subStructureMergeStream) {
+
+    MetaCollection parent = context.getCommitedParent();
+
+    return subStructureMergeStream.filter(result -> !result.isSuccess())
+        .map(result -> result.map(docPartErrorFactory -> createErrorMsgFactory(
+            docPartErrorFactory,
+            parent)
+        ))
+        .findAny()
+        .orElse(ExecutionResult.success());
+  }
+
+  /**
+   * Given a {@link InnerErrorMessageFactory} that uses {@link MetaDocPart}, returns a new
+   * {@link InnerErrorMessageFactory} that uses {@link MetaCollection}.
+   */
+  private InnerErrorMessageFactory<MetaCollection> createErrorMsgFactory(
+      InnerErrorMessageFactory<MetaDocPart> docPartErrFactory,
+      MetaCollection parentCol) {
+    return (colDescFun) -> {
+      return colDescFun.apply(parentCol) + '.'
+          + docPartErrFactory.apply(docPart -> docPart.getIdentifier());
+    };
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpart/DocPartCtx.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpart/DocPartCtx.java
@@ -1,0 +1,44 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.docpart;
+
+import com.torodb.core.transaction.metainf.ChangedElement;
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
+import com.torodb.core.transaction.metainf.MetaElementState;
+import com.torodb.core.transaction.metainf.MutableMetaCollection;
+import com.torodb.core.transaction.metainf.MutableMetaDocPart;
+import com.torodb.metainfo.cache.mvcc.merge.DefaultMergeContext;
+
+/**
+ *
+ */
+public class DocPartCtx extends
+    DefaultMergeContext<ImmutableMetaCollection, MutableMetaDocPart, MutableMetaCollection> {
+
+  public DocPartCtx(ImmutableMetaCollection commitedParent, MutableMetaDocPart changed,
+      MetaElementState change, MutableMetaCollection uncommitedParent) {
+    super(commitedParent, changed, change, uncommitedParent);
+  }
+
+  public DocPartCtx(ImmutableMetaCollection commitedParent,
+      ChangedElement<MutableMetaDocPart> changed, MutableMetaCollection uncommitedParent) {
+    super(commitedParent, changed, uncommitedParent);
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpart/DocPartCtx.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpart/DocPartCtx.java
@@ -23,13 +23,13 @@ import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
 import com.torodb.core.transaction.metainf.MetaElementState;
 import com.torodb.core.transaction.metainf.MutableMetaCollection;
 import com.torodb.core.transaction.metainf.MutableMetaDocPart;
-import com.torodb.metainfo.cache.mvcc.merge.DefaultMergeContext;
+import com.torodb.metainfo.cache.mvcc.merge.ExtendedMergeContext;
 
 /**
  *
  */
 public class DocPartCtx extends
-    DefaultMergeContext<ImmutableMetaCollection, MutableMetaDocPart, MutableMetaCollection> {
+    ExtendedMergeContext<ImmutableMetaCollection, MutableMetaDocPart, MutableMetaCollection> {
 
   public DocPartCtx(ImmutableMetaCollection commitedParent, MutableMetaDocPart changed,
       MetaElementState change, MutableMetaCollection uncommitedParent) {

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpart/DocPartMergeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpart/DocPartMergeStrategy.java
@@ -23,14 +23,11 @@ import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
 import com.torodb.core.transaction.metainf.ImmutableMetaCollection.Builder;
 import com.torodb.core.transaction.metainf.MutableMetaDocPart;
 import com.torodb.metainfo.cache.mvcc.merge.DoNothingMergeStrategy;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
 import com.torodb.metainfo.cache.mvcc.merge.FirstToApplyStrategyPicker;
 import com.torodb.metainfo.cache.mvcc.merge.MergeStrategy;
 import com.torodb.metainfo.cache.mvcc.merge.MergeStrategyPicker;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
 
-/**
- *
- */
 public class DocPartMergeStrategy implements MergeStrategy<ImmutableMetaCollection,
     MutableMetaDocPart, Builder, DocPartCtx> {
 

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpart/DocPartMergeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpart/DocPartMergeStrategy.java
@@ -1,0 +1,59 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.docpart;
+
+import com.google.common.collect.Lists;
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection.Builder;
+import com.torodb.core.transaction.metainf.MutableMetaDocPart;
+import com.torodb.metainfo.cache.mvcc.merge.DoNothingMergeStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.FirstToApplyStrategyPicker;
+import com.torodb.metainfo.cache.mvcc.merge.MergeStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.MergeStrategyPicker;
+
+/**
+ *
+ */
+public class DocPartMergeStrategy implements MergeStrategy<ImmutableMetaCollection,
+    MutableMetaDocPart, Builder, DocPartCtx> {
+
+  @SuppressWarnings("checkstyle:LineLength")
+  private final MergeStrategyPicker<ImmutableMetaCollection, MutableMetaDocPart, Builder, DocPartCtx> delegate;
+
+  public DocPartMergeStrategy() {
+    this.delegate = new FirstToApplyStrategyPicker<>(Lists.newArrayList(
+        new NewDocPartStrategy(),
+        new SameIdOtherRefStrategy(),
+        new SameRefOtherIdStrategy(),
+        new DocPartChildrenStrategy()
+    ), new DoNothingMergeStrategy<>());
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaCollection> execute(
+      DocPartCtx context, Builder parentBuilder) {
+    return delegate.pick(context)
+        .execute(context, parentBuilder);
+  }
+
+
+
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpart/DocPartPartialStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpart/DocPartPartialStrategy.java
@@ -1,0 +1,48 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.docpart;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection.Builder;
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
+import com.torodb.core.transaction.metainf.MutableMetaDocPart;
+import com.torodb.metainfo.cache.mvcc.merge.PartialMergeStrategy;
+
+import javax.annotation.Nullable;
+
+/**
+ *
+ */
+interface DocPartPartialStrategy extends
+    PartialMergeStrategy<ImmutableMetaCollection, MutableMetaDocPart, Builder, DocPartCtx> {
+
+  @Nullable
+  default ImmutableMetaDocPart getCommitedById(DocPartCtx context) {
+    return context.getCommitedParent()
+        .getMetaDocPartByIdentifier(context.getChanged().getIdentifier());
+  }
+
+  @Nullable
+  default ImmutableMetaDocPart getCommitedByTableRef(DocPartCtx context) {
+    return context.getCommitedParent().getMetaDocPartByTableRef(
+        context.getChanged().getTableRef()
+    );
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpart/InsertCollectionStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpart/InsertCollectionStrategy.java
@@ -21,12 +21,9 @@ package com.torodb.metainfo.cache.mvcc.merge.docpart;
 import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
 import com.torodb.core.transaction.metainf.ImmutableMetaCollection.Builder;
 import com.torodb.core.transaction.metainf.MutableMetaDocPart;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
 import com.torodb.metainfo.cache.mvcc.merge.MergeStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
 
-/**
- *
- */
 public class InsertCollectionStrategy
     implements MergeStrategy<ImmutableMetaCollection, MutableMetaDocPart, Builder, DocPartCtx> {
 

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpart/InsertCollectionStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpart/InsertCollectionStrategy.java
@@ -1,0 +1,39 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.docpart;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection.Builder;
+import com.torodb.core.transaction.metainf.MutableMetaDocPart;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.MergeStrategy;
+
+/**
+ *
+ */
+public class InsertCollectionStrategy
+    implements MergeStrategy<ImmutableMetaCollection, MutableMetaDocPart, Builder, DocPartCtx> {
+
+  @Override
+  public ExecutionResult<ImmutableMetaCollection> execute(
+      DocPartCtx context, Builder parentBuilder) {
+    parentBuilder.put(context.getChanged().immutableCopy());
+    return ExecutionResult.success();
+  }
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpart/NewDocPartStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpart/NewDocPartStrategy.java
@@ -1,0 +1,42 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.docpart;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection.Builder;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+
+/**
+ *
+ */
+class NewDocPartStrategy implements DocPartPartialStrategy {
+
+  @Override
+  public boolean appliesTo(DocPartCtx context) {
+    return getCommitedById(context) == null && getCommitedByTableRef(context) == null;
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaCollection> execute(DocPartCtx context, Builder parentBuilder)
+      throws IllegalArgumentException {
+    parentBuilder.put(context.getChanged().immutableCopy());
+    return ExecutionResult.success();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpart/NewDocPartStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpart/NewDocPartStrategy.java
@@ -20,10 +20,10 @@ package com.torodb.metainfo.cache.mvcc.merge.docpart;
 
 import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
 import com.torodb.core.transaction.metainf.ImmutableMetaCollection.Builder;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
 
 /**
- *
+ * The strategy used when there is no commited doc part with the same table ref and identifier.
  */
 class NewDocPartStrategy implements DocPartPartialStrategy {
 

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpart/SameIdOtherRefStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpart/SameIdOtherRefStrategy.java
@@ -1,0 +1,61 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.docpart;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection.Builder;
+import com.torodb.core.transaction.metainf.MetaDocPart;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+
+
+/**
+ *
+ */
+class SameIdOtherRefStrategy implements DocPartPartialStrategy {
+
+  @Override
+  public ExecutionResult<ImmutableMetaCollection> execute(
+      DocPartCtx context, Builder parentBuilder) throws IllegalArgumentException {
+    return ExecutionResult.error(
+        getClass(),
+        parentDescFun -> getErrorMessage(context, parentDescFun)
+    );
+  }
+
+  @Override
+  public boolean appliesTo(DocPartCtx context) {
+    MetaDocPart byId = getCommitedById(context);
+    return byId != null && !byId.getTableRef().equals(context.getChanged().getTableRef());
+  }
+
+  private String getErrorMessage(
+      DocPartCtx context,
+      ParentDescriptionFun<ImmutableMetaCollection> parentDescription) {
+    MetaDocPart changed = context.getChanged();
+    MetaDocPart byId = getCommitedById(context);
+    assert byId != null;
+    String parent = parentDescription.apply(context.getCommitedParent());
+
+    return "There is a previous doc part on " + parent + " whose id is " + byId.getIdentifier()
+        + " that has a different ref. The previous element ref is " + byId.getTableRef()
+        + " and the new one is " + changed.getTableRef();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpart/SameIdOtherRefStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpart/SameIdOtherRefStrategy.java
@@ -21,8 +21,8 @@ package com.torodb.metainfo.cache.mvcc.merge.docpart;
 import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
 import com.torodb.core.transaction.metainf.ImmutableMetaCollection.Builder;
 import com.torodb.core.transaction.metainf.MetaDocPart;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ParentDescriptionFun;
 
 
 /**

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpart/SameRefOtherIdStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpart/SameRefOtherIdStrategy.java
@@ -20,9 +20,8 @@ package com.torodb.metainfo.cache.mvcc.merge.docpart;
 
 import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
 import com.torodb.core.transaction.metainf.MetaDocPart;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
-
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ParentDescriptionFun;
 
 /**
  *

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpart/SameRefOtherIdStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpart/SameRefOtherIdStrategy.java
@@ -1,0 +1,61 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.docpart;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
+import com.torodb.core.transaction.metainf.MetaDocPart;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+
+/**
+ *
+ */
+class SameRefOtherIdStrategy implements DocPartPartialStrategy {
+
+  @Override
+  public boolean appliesTo(DocPartCtx context) {
+    MetaDocPart byRef = getCommitedByTableRef(context);
+    return byRef != null && !byRef.getIdentifier().equals(context.getChanged().getIdentifier());
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaCollection> execute(
+      DocPartCtx context,
+      ImmutableMetaCollection.Builder parentBuilder) throws IllegalArgumentException {
+    return ExecutionResult.error(
+        getClass(),
+        parentDescFun -> getErrorMessage(context, parentDescFun)
+    );
+  }
+
+  private String getErrorMessage(DocPartCtx context,
+      ParentDescriptionFun<ImmutableMetaCollection> parentDescription) {
+    MetaDocPart changed = context.getChanged();
+    MetaDocPart byRef = getCommitedByTableRef(context);
+    assert byRef != null;
+    String parent = parentDescription.apply(context.getCommitedParent());
+
+    return "There is a previous doc part on " + parent + " whose ref is " + byRef.getTableRef()
+        + " that has a different id. The previous element id is " + byRef.getIdentifier()
+        + " and the new one is " + changed.getIdentifier();
+
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/DocPartIndexChildrenStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/DocPartIndexChildrenStrategy.java
@@ -23,15 +23,13 @@ import com.torodb.core.transaction.metainf.ImmutableMetaIdentifiedDocPartIndex;
 import com.torodb.core.transaction.metainf.ImmutableMetaIdentifiedDocPartIndex.Builder;
 import com.torodb.core.transaction.metainf.MetaIdentifiedDocPartIndex;
 import com.torodb.metainfo.cache.mvcc.merge.ChildrenMergePartialStrategy;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
 import com.torodb.metainfo.cache.mvcc.merge.index.field.column.IndexColumnCtx;
 import com.torodb.metainfo.cache.mvcc.merge.index.field.column.IndexColumnMergeStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ParentDescriptionFun;
 
 import java.util.stream.Stream;
 
-/**
- *
- */
 public class DocPartIndexChildrenStrategy extends ChildrenMergePartialStrategy<
     ImmutableMetaDocPart, MetaIdentifiedDocPartIndex, ImmutableMetaDocPart.Builder, DocPartIndexCtx,
     Builder, ImmutableMetaIdentifiedDocPartIndex>
@@ -73,7 +71,7 @@ public class DocPartIndexChildrenStrategy extends ChildrenMergePartialStrategy<
 
   @Override
   protected String describeChanged(
-      ExecutionResult.ParentDescriptionFun<ImmutableMetaDocPart> parentDescFun,
+      ParentDescriptionFun<ImmutableMetaDocPart> parentDescFun,
       ImmutableMetaDocPart parent, ImmutableMetaIdentifiedDocPartIndex immutableSelf) {
     return parentDescFun.apply(parent) + '.' + immutableSelf.getIdentifier();
   }

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/DocPartIndexChildrenStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/DocPartIndexChildrenStrategy.java
@@ -1,0 +1,81 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.docpartindex;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
+import com.torodb.core.transaction.metainf.ImmutableMetaIdentifiedDocPartIndex;
+import com.torodb.core.transaction.metainf.ImmutableMetaIdentifiedDocPartIndex.Builder;
+import com.torodb.core.transaction.metainf.MetaIdentifiedDocPartIndex;
+import com.torodb.metainfo.cache.mvcc.merge.ChildrenMergePartialStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.index.field.column.IndexColumnCtx;
+import com.torodb.metainfo.cache.mvcc.merge.index.field.column.IndexColumnMergeStrategy;
+
+import java.util.stream.Stream;
+
+/**
+ *
+ */
+public class DocPartIndexChildrenStrategy extends ChildrenMergePartialStrategy<
+    ImmutableMetaDocPart, MetaIdentifiedDocPartIndex, ImmutableMetaDocPart.Builder, DocPartIndexCtx,
+    Builder, ImmutableMetaIdentifiedDocPartIndex>
+    implements DocPartIndexPartialStrategy {
+
+  private final IndexColumnMergeStrategy columnStrategy = new IndexColumnMergeStrategy();
+
+  @Override
+  public boolean appliesTo(DocPartIndexCtx context) {
+    return getCommitedById(context) == null;
+  }
+
+  @Override
+  protected ImmutableMetaIdentifiedDocPartIndex.Builder createSelfBuilder(DocPartIndexCtx context) {
+    ImmutableMetaIdentifiedDocPartIndex oldById = getCommitedById(context);
+    assert oldById != null;
+
+    return new ImmutableMetaIdentifiedDocPartIndex.Builder(oldById);
+  }
+
+  @Override
+  protected Stream<ExecutionResult<ImmutableMetaIdentifiedDocPartIndex>> streamChildResults(
+      DocPartIndexCtx context, Builder selfBuilder) {
+    ImmutableMetaIdentifiedDocPartIndex oldById = getCommitedById(context);
+    return context.getChanged().streamColumns()
+        .map(column -> new IndexColumnCtx(
+            oldById,
+            column,
+            context.getChanged()
+        ))
+        .map(ctx -> columnStrategy.execute(ctx, selfBuilder));
+  }
+
+  @Override
+  protected void changeParent(ImmutableMetaDocPart.Builder parentBuilder,
+      ImmutableMetaIdentifiedDocPartIndex.Builder selfBuilder) {
+    parentBuilder.put(selfBuilder);
+  }
+
+  @Override
+  protected String describeChanged(
+      ExecutionResult.ParentDescriptionFun<ImmutableMetaDocPart> parentDescFun,
+      ImmutableMetaDocPart parent, ImmutableMetaIdentifiedDocPartIndex immutableSelf) {
+    return parentDescFun.apply(parent) + '.' + immutableSelf.getIdentifier();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/DocPartIndexCtx.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/DocPartIndexCtx.java
@@ -25,12 +25,12 @@ import com.torodb.core.transaction.metainf.MetaElementState;
 import com.torodb.core.transaction.metainf.MetaIdentifiedDocPartIndex;
 import com.torodb.core.transaction.metainf.MutableMetaCollection;
 import com.torodb.core.transaction.metainf.MutableMetaDocPart;
-import com.torodb.metainfo.cache.mvcc.merge.DefaultMergeContext;
+import com.torodb.metainfo.cache.mvcc.merge.ExtendedMergeContext;
 
 /**
  *
  */
-public class DocPartIndexCtx extends DefaultMergeContext<ImmutableMetaDocPart,
+public class DocPartIndexCtx extends ExtendedMergeContext<ImmutableMetaDocPart,
     MetaIdentifiedDocPartIndex, MutableMetaDocPart> {
 
   private final ImmutableMetaCollection commitedCollection;

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/DocPartIndexCtx.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/DocPartIndexCtx.java
@@ -1,0 +1,66 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.docpartindex;
+
+import com.torodb.core.transaction.metainf.ChangedElement;
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
+import com.torodb.core.transaction.metainf.MetaElementState;
+import com.torodb.core.transaction.metainf.MetaIdentifiedDocPartIndex;
+import com.torodb.core.transaction.metainf.MutableMetaCollection;
+import com.torodb.core.transaction.metainf.MutableMetaDocPart;
+import com.torodb.metainfo.cache.mvcc.merge.DefaultMergeContext;
+
+/**
+ *
+ */
+public class DocPartIndexCtx extends DefaultMergeContext<ImmutableMetaDocPart,
+    MetaIdentifiedDocPartIndex, MutableMetaDocPart> {
+
+  private final ImmutableMetaCollection commitedCollection;
+  private final MutableMetaCollection uncommitedCollection;
+
+  public DocPartIndexCtx(ImmutableMetaDocPart commitedParent,
+      ChangedElement<? extends MetaIdentifiedDocPartIndex> changed,
+      MutableMetaDocPart uncommitedParent, ImmutableMetaCollection commitedCollection,
+      MutableMetaCollection uncommitedCollection) {
+    super(commitedParent, changed, uncommitedParent);
+    this.commitedCollection = commitedCollection;
+    this.uncommitedCollection = uncommitedCollection;
+  }
+
+  public DocPartIndexCtx(ImmutableMetaDocPart commitedParent,
+      MetaIdentifiedDocPartIndex changed, MetaElementState change,
+      MutableMetaDocPart uncommitedParent, ImmutableMetaCollection commitedCollection,
+      MutableMetaCollection uncommitedCollection) {
+    super(commitedParent, changed, change, uncommitedParent);
+    this.commitedCollection = commitedCollection;
+    this.uncommitedCollection = uncommitedCollection;
+  }
+
+  public ImmutableMetaCollection getCommitedCollection() {
+    return commitedCollection;
+  }
+
+  public MutableMetaCollection getUncommitedCollection() {
+    return uncommitedCollection;
+  }
+
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/DocPartIndexMergeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/DocPartIndexMergeStrategy.java
@@ -1,0 +1,86 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.docpartindex;
+
+import com.google.common.collect.Lists;
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart.Builder;
+import com.torodb.core.transaction.metainf.MetaIdentifiedDocPartIndex;
+import com.torodb.metainfo.cache.mvcc.merge.ByStateStrategyPicker;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.FirstToApplyStrategyPicker;
+import com.torodb.metainfo.cache.mvcc.merge.MergeStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.MergeStrategyPicker;
+
+/**
+ *
+ */
+public class DocPartIndexMergeStrategy implements
+    MergeStrategy<ImmutableMetaDocPart, MetaIdentifiedDocPartIndex, Builder, DocPartIndexCtx> {
+
+  private final MergeStrategyPicker<ImmutableMetaDocPart, MetaIdentifiedDocPartIndex, Builder,
+      DocPartIndexCtx> delegate;
+
+  public DocPartIndexMergeStrategy() {
+    delegate = new ByStateStrategyPicker<>(
+        createOnAddStrategy(),
+        createOnModifyStrategy(),
+        createOnRemoveStrategy()
+    );
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaDocPart> execute(DocPartIndexCtx context,
+      Builder parentBuilder) {
+    return delegate.pick(context)
+        .execute(context, parentBuilder);
+  }
+
+  private static MergeStrategyPicker<ImmutableMetaDocPart, MetaIdentifiedDocPartIndex, Builder,
+      DocPartIndexCtx> createOnAddStrategy() {
+    return new FirstToApplyStrategyPicker<>(Lists.newArrayList(
+        new NoDocIndexStrategy(),
+        new NewDocPartIndexStrategy(),
+        new DocPartIndexChildrenStrategy()
+    ));
+  }
+
+  @SuppressWarnings("checkstyle:LineLength")
+  private static MergeStrategyPicker<ImmutableMetaDocPart, MetaIdentifiedDocPartIndex, Builder,
+      DocPartIndexCtx> createOnModifyStrategy() {
+    return createOnAddStrategy();
+  }
+
+  @SuppressWarnings("checkstyle:LineLength")
+  private static MergeStrategyPicker<ImmutableMetaDocPart, MetaIdentifiedDocPartIndex, Builder,
+      DocPartIndexCtx> createOnRemoveStrategy() {
+    return new FirstToApplyStrategyPicker<>(Lists.newArrayList(
+        new MissedDocIndexStrategy(),
+        new NotExistentDocPartIndexStrategy()
+    ), DocPartIndexMergeStrategy::deleteIndex);
+  }
+
+  private static ExecutionResult<ImmutableMetaDocPart> deleteIndex(
+      DocPartIndexCtx ctx, Builder parentBuilder) {
+    parentBuilder.remove(ctx.getChanged());
+    return ExecutionResult.success();
+  }
+
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/DocPartIndexMergeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/DocPartIndexMergeStrategy.java
@@ -23,14 +23,11 @@ import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
 import com.torodb.core.transaction.metainf.ImmutableMetaDocPart.Builder;
 import com.torodb.core.transaction.metainf.MetaIdentifiedDocPartIndex;
 import com.torodb.metainfo.cache.mvcc.merge.ByStateStrategyPicker;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
 import com.torodb.metainfo.cache.mvcc.merge.FirstToApplyStrategyPicker;
 import com.torodb.metainfo.cache.mvcc.merge.MergeStrategy;
 import com.torodb.metainfo.cache.mvcc.merge.MergeStrategyPicker;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
 
-/**
- *
- */
 public class DocPartIndexMergeStrategy implements
     MergeStrategy<ImmutableMetaDocPart, MetaIdentifiedDocPartIndex, Builder, DocPartIndexCtx> {
 

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/DocPartIndexPartialStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/DocPartIndexPartialStrategy.java
@@ -1,0 +1,54 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.docpartindex;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart.Builder;
+import com.torodb.core.transaction.metainf.ImmutableMetaIdentifiedDocPartIndex;
+import com.torodb.core.transaction.metainf.MetaIdentifiedDocPartIndex;
+import com.torodb.metainfo.cache.mvcc.merge.PartialMergeStrategy;
+
+import javax.annotation.Nullable;
+
+
+
+/**
+ *
+ */
+interface DocPartIndexPartialStrategy extends
+    PartialMergeStrategy<ImmutableMetaDocPart, MetaIdentifiedDocPartIndex, Builder,
+    DocPartIndexCtx> {
+
+  @Nullable
+  public default ImmutableMetaIdentifiedDocPartIndex getCommitedById(DocPartIndexCtx context) {
+    return context.getCommitedParent()
+        .getMetaDocPartIndexByIdentifier(context.getChanged().getIdentifier());
+  }
+
+  @Nullable
+  public default ImmutableMetaIdentifiedDocPartIndex getCommitedByColumns(DocPartIndexCtx context) {
+    MetaIdentifiedDocPartIndex changed = context.getChanged();
+    return context.getCommitedParent()
+        .streamIndexes()
+        .filter(oldDocPartIndex -> oldDocPartIndex.hasSameColumns(changed))
+        .findAny()
+        .orElse(null);
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/MissedDocIndexStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/MissedDocIndexStrategy.java
@@ -1,0 +1,128 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.docpartindex;
+
+import com.torodb.core.transaction.metainf.ChangedElement;
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
+import com.torodb.core.transaction.metainf.ImmutableMetaIndex;
+import com.torodb.core.transaction.metainf.MetaCollection;
+import com.torodb.core.transaction.metainf.MetaDocPartIndex;
+import com.torodb.core.transaction.metainf.MetaElementState;
+import com.torodb.core.transaction.metainf.MetaIdentifiedDocPartIndex;
+import com.torodb.core.transaction.metainf.MetaIndex;
+import com.torodb.core.transaction.metainf.MutableMetaCollection;
+import com.torodb.core.transaction.metainf.MutableMetaIndex;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+
+import java.util.Optional;
+
+/**
+ * This strategy tests whether there is a {@link MetaIndex} that uses the {@link MetaDocPartIndex}
+ * that is being deleted.
+ */
+public class MissedDocIndexStrategy implements DocPartIndexPartialStrategy {
+
+  @Override
+  public boolean appliesTo(DocPartIndexCtx context) {
+    if (context.getChange() != MetaElementState.REMOVED) {
+      return false;
+    }
+    return getAnyMissedIndex(context).isPresent();
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaDocPart> execute(DocPartIndexCtx context,
+      ImmutableMetaDocPart.Builder parentBuilder) throws IllegalArgumentException {
+
+    return ExecutionResult.error(
+        getClass(),
+        parentDescFun -> getErrorMessage(parentDescFun, context)
+    );
+  }
+
+  private String getErrorMessage(
+      ParentDescriptionFun<ImmutableMetaDocPart> parentDescFun,
+      DocPartIndexCtx context) {
+    String parentDesc = parentDescFun.apply(context.getCommitedParent());
+    String missedIndex = getAnyMissedIndex(context)
+        .map(MetaIndex::getName)
+        .orElse("unknown");
+
+    return "The already commited index " + missedIndex + " is compatible with the removed "
+        + "doc part index " + parentDesc + "." + context.getChanged().getIdentifier();
+  }
+
+  /**
+   * Looks for a {@link MetaIndex} that is compatible with the removed {@link MetaDocPartIndex} and
+   * hasn't been removed.
+   */
+  public static Optional<ImmutableMetaIndex> getAnyMissedIndex(DocPartIndexCtx ctx) {
+
+    ImmutableMetaCollection oldCol = ctx.getCommitedCollection();
+    MutableMetaCollection newCol = ctx.getUncommitedCollection();
+    MetaIdentifiedDocPartIndex changed = ctx.getChanged();
+
+    Optional<ImmutableMetaIndex> result = oldCol.streamContainedMetaIndexes()
+        .flatMap(oldIndex -> oldIndex.streamTableRefs()
+            .map(tableRef -> oldCol.getMetaDocPartByTableRef(tableRef))
+            .filter(oldDocPart -> oldDocPart != null && oldIndex.isCompatible(oldDocPart,
+                changed) && newCol.streamModifiedMetaIndexes()
+                    .noneMatch(newIndex -> newIndex.getChange() == MetaElementState.REMOVED
+                        && newIndex.getElement().getName().equals(oldIndex.getName())))
+            .map(tableRef -> oldIndex))
+        .findAny();
+
+    //gortiz: It is very difficult to read the stream above. I am temporally adding this
+    //new sentence that should be equivalent
+    assert result.orElse(null) == oldCol.streamContainedMetaIndexes()
+        .filter(oldIndex -> areCompatible(oldCol, oldIndex, changed))
+        .filter(oldIndex -> !hasBeenRemoved(newCol, oldIndex))
+        .findAny()
+        .orElse(null);
+
+    return result;
+  }
+
+  /**
+   * Returns true iff the given {@link MetaIndex} is compatible with the given 
+   * {@link MetaIdentifiedDocPartIndex} on the given {@link MetaCollection}.
+   */
+  private static boolean areCompatible(MetaCollection oldCol, MetaIndex oldIndex,
+      MetaIdentifiedDocPartIndex changed) {
+    return oldIndex.streamTableRefs()
+        .map(tableRef -> oldCol.getMetaDocPartByTableRef(tableRef))
+        .filter(oldDocPart -> oldDocPart != null)
+        .anyMatch(oldDocPart -> oldIndex.isCompatible(oldDocPart, changed));
+  }
+
+  /**
+   * Returns true iff the given index has been removed on the given mutable collection.
+   */
+  private static boolean hasBeenRemoved(MutableMetaCollection newCol, MetaIndex oldIndex) {
+    Optional<ChangedElement<MutableMetaIndex>> modifiedIndex = newCol.getModifiedMetaIndexByName(
+        oldIndex.getName());
+    if (!modifiedIndex.isPresent()) {
+      return false;
+    }
+    return modifiedIndex.get().getChange() == MetaElementState.REMOVED;
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/MissedDocIndexStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/MissedDocIndexStrategy.java
@@ -29,8 +29,8 @@ import com.torodb.core.transaction.metainf.MetaIdentifiedDocPartIndex;
 import com.torodb.core.transaction.metainf.MetaIndex;
 import com.torodb.core.transaction.metainf.MutableMetaCollection;
 import com.torodb.core.transaction.metainf.MutableMetaIndex;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ParentDescriptionFun;
 
 import java.util.Optional;
 

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/NewDocPartIndexStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/NewDocPartIndexStrategy.java
@@ -19,10 +19,10 @@
 package com.torodb.metainfo.cache.mvcc.merge.docpartindex;
 
 import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
 
 /**
- *
+ * The strategy used when there is no commited collection with the identifier.
  */
 public class NewDocPartIndexStrategy implements DocPartIndexPartialStrategy {
 

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/NewDocPartIndexStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/NewDocPartIndexStrategy.java
@@ -1,0 +1,41 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.docpartindex;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+
+/**
+ *
+ */
+public class NewDocPartIndexStrategy implements DocPartIndexPartialStrategy {
+
+  @Override
+  public boolean appliesTo(DocPartIndexCtx context) {
+    return getCommitedById(context) == null;
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaDocPart> execute(DocPartIndexCtx context,
+      ImmutableMetaDocPart.Builder parentBuilder) throws IllegalArgumentException {
+    parentBuilder.put(context.getChanged().immutableCopy());
+    return ExecutionResult.success();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/NoDocIndexStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/NoDocIndexStrategy.java
@@ -1,0 +1,88 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.docpartindex;
+
+import com.torodb.core.transaction.metainf.ChangedElement;
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
+import com.torodb.core.transaction.metainf.ImmutableMetaIndex;
+import com.torodb.core.transaction.metainf.MetaDocPartIndex;
+import com.torodb.core.transaction.metainf.MetaIndex;
+import com.torodb.core.transaction.metainf.MutableMetaCollection;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+
+import java.util.Optional;
+
+/**
+ * This strategy tests whether there is a {@link MetaIndex} that uses the {@link MetaDocPartIndex}
+ * that is being analyzed.
+ */
+//TODO (gortiz): I think this test is incorrect (does not check whether the found index is
+//planned to be deleted)
+public class NoDocIndexStrategy implements DocPartIndexPartialStrategy {
+
+  @Override
+  public boolean appliesTo(DocPartIndexCtx context) {
+    return !getAnyRelatedIndex(context).isPresent();
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaDocPart> execute(DocPartIndexCtx context,
+      ImmutableMetaDocPart.Builder parentBuilder) throws IllegalArgumentException {
+    return ExecutionResult.error(
+        getClass(),
+        parentDescFun -> getErrorMessage(parentDescFun, context)
+    );
+  }
+
+  private String getErrorMessage(
+      ExecutionResult.ParentDescriptionFun<ImmutableMetaDocPart> parentDescFun,
+      DocPartIndexCtx context) {
+    String parentDesc = parentDescFun.apply(context.getCommitedParent());
+
+    return "There is a new doc part index " + parentDesc + "." + context.getChanged() + " that "
+        + "has no index associated";
+  }
+
+  public static Optional<? extends MetaIndex> getAnyRelatedIndex(DocPartIndexCtx context) {
+
+    MutableMetaCollection uncommmitedCol = context.getUncommitedCollection();
+
+    Optional<? extends MetaIndex> anyNewRelatedIndex = uncommmitedCol.streamModifiedMetaIndexes()
+        .map(ChangedElement::getElement)
+        .filter(newIndex -> newIndex.isCompatible(
+            context.getUncommitedParent(),
+            context.getChanged()))
+        .findAny();
+
+    if (anyNewRelatedIndex.isPresent()) {
+      return anyNewRelatedIndex;
+    }
+
+    ImmutableMetaCollection commitedCol = context.getCommitedCollection();
+
+    Optional<ImmutableMetaIndex> anyOldRelatedIndex = commitedCol.streamContainedMetaIndexes()
+        .filter(newIndex -> newIndex.isCompatible(
+            context.getUncommitedParent(),
+            context.getChanged()))
+        .findAny();
+
+    return anyOldRelatedIndex;
+  }
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/NoDocIndexStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/NoDocIndexStrategy.java
@@ -25,7 +25,8 @@ import com.torodb.core.transaction.metainf.ImmutableMetaIndex;
 import com.torodb.core.transaction.metainf.MetaDocPartIndex;
 import com.torodb.core.transaction.metainf.MetaIndex;
 import com.torodb.core.transaction.metainf.MutableMetaCollection;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ParentDescriptionFun;
 
 import java.util.Optional;
 
@@ -52,7 +53,7 @@ public class NoDocIndexStrategy implements DocPartIndexPartialStrategy {
   }
 
   private String getErrorMessage(
-      ExecutionResult.ParentDescriptionFun<ImmutableMetaDocPart> parentDescFun,
+      ParentDescriptionFun<ImmutableMetaDocPart> parentDescFun,
       DocPartIndexCtx context) {
     String parentDesc = parentDescFun.apply(context.getCommitedParent());
 

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/NotExistentDocPartIndexStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/NotExistentDocPartIndexStrategy.java
@@ -21,7 +21,7 @@ package com.torodb.metainfo.cache.mvcc.merge.docpartindex;
 import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
 import com.torodb.core.transaction.metainf.ImmutableMetaDocPart.Builder;
 import com.torodb.core.transaction.metainf.MetaElementState;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
 
 
 /**

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/NotExistentDocPartIndexStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/docpartindex/NotExistentDocPartIndexStrategy.java
@@ -1,0 +1,52 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.docpartindex;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart.Builder;
+import com.torodb.core.transaction.metainf.MetaElementState;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+
+
+/**
+ * A partial strategy that applies when a doc part index is being removed but it is not found on
+ * the commited doc part.
+ *
+ * <p/>This can happen when a doc part index is created and removed on the same transaction or when
+ * merging a transaction that removes a doc part index that has been already removed by a concurrent
+ * transaction that has been commited after this one is created but before it is commited.
+ */
+class NotExistentDocPartIndexStrategy implements DocPartIndexPartialStrategy {
+
+  @Override
+  public boolean appliesTo(DocPartIndexCtx context) {
+    MetaElementState change = context.getChange();
+    if (change != MetaElementState.REMOVED) {
+      return false;
+    }
+    return getCommitedById(context) == null && getCommitedByColumns(context) == null;
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaDocPart> execute(DocPartIndexCtx context,
+      Builder parentBuilder) throws IllegalArgumentException {
+    return ExecutionResult.success();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/FieldContext.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/FieldContext.java
@@ -24,13 +24,13 @@ import com.torodb.core.transaction.metainf.MetaElementState;
 import com.torodb.core.transaction.metainf.MetaField;
 import com.torodb.core.transaction.metainf.MutableMetaCollection;
 import com.torodb.core.transaction.metainf.MutableMetaDocPart;
-import com.torodb.metainfo.cache.mvcc.merge.DefaultMergeContext;
+import com.torodb.metainfo.cache.mvcc.merge.ExtendedMergeContext;
 
 /**
  *
  */
 public class FieldContext 
-    extends DefaultMergeContext<ImmutableMetaDocPart, MetaField, MutableMetaDocPart> {
+    extends ExtendedMergeContext<ImmutableMetaDocPart, MetaField, MutableMetaDocPart> {
 
   private final ImmutableMetaCollection commitedCollection;
   private final MutableMetaCollection uncommitedCollection;

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/FieldContext.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/FieldContext.java
@@ -1,0 +1,57 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.field;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
+import com.torodb.core.transaction.metainf.MetaElementState;
+import com.torodb.core.transaction.metainf.MetaField;
+import com.torodb.core.transaction.metainf.MutableMetaCollection;
+import com.torodb.core.transaction.metainf.MutableMetaDocPart;
+import com.torodb.metainfo.cache.mvcc.merge.DefaultMergeContext;
+
+/**
+ *
+ */
+public class FieldContext 
+    extends DefaultMergeContext<ImmutableMetaDocPart, MetaField, MutableMetaDocPart> {
+
+  private final ImmutableMetaCollection commitedCollection;
+  private final MutableMetaCollection uncommitedCollection;
+
+  public FieldContext(
+      ImmutableMetaDocPart commitedParent,
+      MetaField changed,
+      MutableMetaDocPart uncommitedParent,
+      ImmutableMetaCollection commitedCollection,
+      MutableMetaCollection uncommitedCollection) {
+    super(commitedParent, changed, MetaElementState.ADDED, uncommitedParent);
+    this.commitedCollection = commitedCollection;
+    this.uncommitedCollection = uncommitedCollection;
+  }
+
+  public ImmutableMetaCollection getCommitedCollection() {
+    return commitedCollection;
+  }
+
+  public MutableMetaCollection getUncommitedCollection() {
+    return uncommitedCollection;
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/FieldMergeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/FieldMergeStrategy.java
@@ -1,0 +1,56 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.field;
+
+import com.google.common.collect.Lists;
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart.Builder;
+import com.torodb.core.transaction.metainf.MetaField;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.FirstToApplyStrategyPicker;
+import com.torodb.metainfo.cache.mvcc.merge.MergeStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.MergeStrategyPicker;
+
+/**
+ *
+ */
+public class FieldMergeStrategy 
+    implements MergeStrategy<ImmutableMetaDocPart, MetaField, Builder, FieldContext> {
+
+  @SuppressWarnings("checkstyle:LineLength")
+  private final MergeStrategyPicker<ImmutableMetaDocPart, MetaField, Builder, FieldContext> delegate;
+
+  public FieldMergeStrategy() {
+    delegate = new FirstToApplyStrategyPicker<>(Lists.newArrayList(
+        new SameIdOtherNameStrategy(),
+        new SameIdOtherTypeStrategy(),
+        new SameTypeOtherIdStrategy(),
+        new MissingIndexStrategy(),
+        new NewFieldStrategy()
+    ));
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaDocPart> execute(
+      FieldContext context, Builder parentBuilder) {
+    return delegate.pick(context)
+        .execute(context, parentBuilder);
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/FieldMergeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/FieldMergeStrategy.java
@@ -22,10 +22,10 @@ import com.google.common.collect.Lists;
 import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
 import com.torodb.core.transaction.metainf.ImmutableMetaDocPart.Builder;
 import com.torodb.core.transaction.metainf.MetaField;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
 import com.torodb.metainfo.cache.mvcc.merge.FirstToApplyStrategyPicker;
 import com.torodb.metainfo.cache.mvcc.merge.MergeStrategy;
 import com.torodb.metainfo.cache.mvcc.merge.MergeStrategyPicker;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
 
 /**
  *

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/FieldPartialStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/FieldPartialStrategy.java
@@ -1,0 +1,49 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.field;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
+import com.torodb.core.transaction.metainf.MetaField;
+import com.torodb.metainfo.cache.mvcc.merge.PartialMergeStrategy;
+
+import javax.annotation.Nullable;
+
+
+/**
+ *
+ */
+interface FieldPartialStrategy extends PartialMergeStrategy<ImmutableMetaDocPart,
+    MetaField, ImmutableMetaDocPart.Builder, FieldContext> {
+
+  @Nullable
+  default MetaField getCommitedById(FieldContext context) {
+    return context.getCommitedParent()
+        .getMetaFieldByIdentifier(context.getChanged().getIdentifier());
+  }
+
+  @Nullable
+  default MetaField getCommitedByNameAndType(FieldContext context) {
+    MetaField changed = context.getChanged();
+    return context.getCommitedParent().getMetaFieldByNameAndType(
+        changed.getName(),
+        changed.getType()
+    );
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/MissingIndexStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/MissingIndexStrategy.java
@@ -22,7 +22,8 @@ import com.torodb.core.TableRef;
 import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
 import com.torodb.core.transaction.metainf.MetaIndex;
 import com.torodb.core.transaction.metainf.MutableMetaDocPart;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ParentDescriptionFun;
 import org.jooq.lambda.Seq;
 
 import java.util.Optional;
@@ -57,7 +58,7 @@ public class MissingIndexStrategy implements FieldPartialStrategy {
   }
 
   private String getErrorMessage(
-      ExecutionResult.ParentDescriptionFun<ImmutableMetaDocPart> parentDescFun,
+      ParentDescriptionFun<ImmutableMetaDocPart> parentDescFun,
       FieldContext context) {
     String missed = getAnyMissedIndex(context)
         .map(index -> index.getName())

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/MissingIndexStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/MissingIndexStrategy.java
@@ -1,0 +1,100 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.field;
+
+import com.torodb.core.TableRef;
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
+import com.torodb.core.transaction.metainf.MetaIndex;
+import com.torodb.core.transaction.metainf.MutableMetaDocPart;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import org.jooq.lambda.Seq;
+
+import java.util.Optional;
+
+/**
+ *
+ */
+public class MissingIndexStrategy implements FieldPartialStrategy {
+
+  @Override
+  public boolean appliesTo(FieldContext context) {
+    return getCommitedById(context) == null
+        && getCommitedByNameAndType(context) == null
+        && getAnyMissedIndex(context).isPresent();
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaDocPart> execute(FieldContext context,
+      ImmutableMetaDocPart.Builder parentBuilder) throws IllegalArgumentException {
+
+    return ExecutionResult.error(
+        getClass(),
+        parentDescFun -> getErrorMessage(parentDescFun, context)
+    );
+
+  }
+
+  public static Optional<? extends MetaIndex> getAnyMissedIndex(FieldContext ctx) {
+    return ctx.getCommitedCollection().streamContainedMetaIndexes()
+        .filter(oldIndex -> isMissedIndex(ctx, oldIndex))
+        .findAny();
+  }
+
+  private String getErrorMessage(
+      ExecutionResult.ParentDescriptionFun<ImmutableMetaDocPart> parentDescFun,
+      FieldContext context) {
+    String missed = getAnyMissedIndex(context)
+        .map(index -> index.getName())
+        .orElse("unknown");
+
+    String parentDesc = parentDescFun.apply(context.getCommitedParent());
+
+    return "The new field " + parentDesc + '.' + context.getChanged().getName() + " cannot be "
+        + "commited as it should be indexed by index " + missed + " but it is not";
+
+  }
+
+  private static boolean isMissedIndex(FieldContext ctx, MetaIndex oldIndex) {
+
+    TableRef tableRef = ctx.getCommitedParent().getTableRef();
+    String fieldName = ctx.getChanged().getName();
+    if (oldIndex.getMetaIndexFieldByTableRefAndName(tableRef, fieldName) == null) {
+      //If the old index didn't have the new field we don't care about this index
+      return false;
+    }
+
+    if (ctx.getUncommitedCollection().getMetaIndexByName(oldIndex.getName()) == null) {
+      //if the current collection does not contains an index with the same name as the old index,
+      //then the index is missing
+      return true;
+    }
+
+    MutableMetaDocPart newStructure = ctx.getUncommitedParent();
+
+    boolean anyMatch = Seq.seq(oldIndex.iteratorMetaDocPartIndexesIdentifiers(newStructure))
+        .filter(identifiers -> identifiers.contains(ctx.getChanged().getIdentifier()))
+        .anyMatch(identifiers -> newStructure.streamIndexes()
+            .noneMatch(newDocPartIndex -> oldIndex.isMatch(newStructure, identifiers,
+                newDocPartIndex)));
+
+    return anyMatch;
+
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/NewFieldStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/NewFieldStrategy.java
@@ -1,0 +1,42 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.field;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart.Builder;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+
+/**
+ *
+ */
+class NewFieldStrategy implements FieldPartialStrategy {
+
+  @Override
+  public boolean appliesTo(FieldContext context) {
+    return getCommitedById(context) == null && getCommitedByNameAndType(context) == null;
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaDocPart> execute(FieldContext context, Builder parentBuilder)
+      throws IllegalArgumentException {
+    parentBuilder.put(context.getChanged().immutableCopy());
+    return ExecutionResult.success();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/NewFieldStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/NewFieldStrategy.java
@@ -20,10 +20,11 @@ package com.torodb.metainfo.cache.mvcc.merge.field;
 
 import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
 import com.torodb.core.transaction.metainf.ImmutableMetaDocPart.Builder;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
 
 /**
- *
+ * The strategy used when there is no commited collection with the same identifier and (type and
+ * name).
  */
 class NewFieldStrategy implements FieldPartialStrategy {
 

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/SameIdOtherNameStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/SameIdOtherNameStrategy.java
@@ -1,0 +1,62 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.field;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
+import com.torodb.core.transaction.metainf.MetaField;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+
+
+/**
+ *
+ */
+class SameIdOtherNameStrategy implements FieldPartialStrategy {
+
+  @Override
+  public boolean appliesTo(FieldContext context) {
+    MetaField changed = context.getChanged();
+    MetaField byId = getCommitedById(context);
+    return byId != null && !byId.getName().equals(changed.getName());
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaDocPart> execute(
+      FieldContext context, ImmutableMetaDocPart.Builder callback) throws
+      IllegalArgumentException {
+    return ExecutionResult.error(
+        getClass(),
+        parentDescFun -> getErrorMessage(parentDescFun, context));
+  }
+
+  private String getErrorMessage(
+      ParentDescriptionFun<ImmutableMetaDocPart> parentDescFun,
+      FieldContext context) {
+    MetaField changed = context.getChanged();
+    MetaField byId = getCommitedById(context);
+    assert byId != null;
+    String parent = parentDescFun.apply(context.getCommitedParent());
+
+    return "The meta field " + parent + '.' + changed.getIdentifier() + " with name "
+        + changed.getName() + " and type " + changed.getType() + " cannot be commited because "
+        + "there is an already commited field identified as " + byId.getIdentifier() + " whose "
+        + "name is " + byId.getName();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/SameIdOtherNameStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/SameIdOtherNameStrategy.java
@@ -20,8 +20,8 @@ package com.torodb.metainfo.cache.mvcc.merge.field;
 
 import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
 import com.torodb.core.transaction.metainf.MetaField;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ParentDescriptionFun;
 
 
 /**

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/SameIdOtherTypeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/SameIdOtherTypeStrategy.java
@@ -20,8 +20,8 @@ package com.torodb.metainfo.cache.mvcc.merge.field;
 
 import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
 import com.torodb.core.transaction.metainf.MetaField;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ParentDescriptionFun;
 
 
 /**

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/SameIdOtherTypeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/SameIdOtherTypeStrategy.java
@@ -1,0 +1,63 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.field;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
+import com.torodb.core.transaction.metainf.MetaField;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+
+
+/**
+ *
+ */
+class SameIdOtherTypeStrategy implements FieldPartialStrategy {
+
+  @Override
+  public boolean appliesTo(FieldContext context) {
+    MetaField changed = context.getChanged();
+    MetaField byId = getCommitedById(context);
+    return byId != null && !byId.getType().equals(changed.getType());
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaDocPart> execute(
+      FieldContext context, ImmutableMetaDocPart.Builder callback) throws
+      IllegalArgumentException {
+    return ExecutionResult.error(
+        getClass(),
+        parentDescFun -> getErrorMessage(parentDescFun, context)
+    );
+  }
+
+  private String getErrorMessage(
+      ParentDescriptionFun<ImmutableMetaDocPart> parentDescFun,
+      FieldContext context) {
+    MetaField changed = context.getChanged();
+    MetaField byId = getCommitedById(context);
+    assert byId != null;
+    String parent = parentDescFun.apply(context.getCommitedParent());
+
+    return "The meta field " + parent + '.' + changed.getIdentifier() + " with name "
+        + changed.getName() + " and " + "type " + changed.getType() + " cannot be commited, as "
+        + "there is an already commited field identified as " + byId.getIdentifier() + " whose "
+        + "type is " + byId.getType();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/SameTypeOtherIdStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/SameTypeOtherIdStrategy.java
@@ -20,8 +20,8 @@ package com.torodb.metainfo.cache.mvcc.merge.field;
 
 import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
 import com.torodb.core.transaction.metainf.MetaField;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ParentDescriptionFun;
 
 
 /**

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/SameTypeOtherIdStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/field/SameTypeOtherIdStrategy.java
@@ -1,0 +1,63 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.field;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
+import com.torodb.core.transaction.metainf.MetaField;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+
+
+/**
+ *
+ */
+class SameTypeOtherIdStrategy implements FieldPartialStrategy {
+
+  @Override
+  public boolean appliesTo(FieldContext context) {
+    MetaField changed = context.getChanged();
+    MetaField byNameAndType = getCommitedByNameAndType(context);
+    return byNameAndType != null && !byNameAndType.getIdentifier().equals(changed.getIdentifier());
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaDocPart> execute(
+      FieldContext context, ImmutableMetaDocPart.Builder callback) throws
+      IllegalArgumentException {
+    return ExecutionResult.error(
+        getClass(),
+        parentDescFun -> getErrorMessage(parentDescFun, context)
+    );
+  }
+
+  private String getErrorMessage(
+      ParentDescriptionFun<ImmutableMetaDocPart> parentDescFun,
+      FieldContext context) {
+    MetaField changed = context.getChanged();
+    MetaField byTypeAndType = getCommitedByNameAndType(context);
+    assert byTypeAndType != null;
+    String parent = parentDescFun.apply(context.getCommitedParent());
+
+    return "The meta field " + parent + '.' + changed.getIdentifier() + " with name "
+        + changed.getName() + " and type " + changed.getType() + " cannot be commited because "
+        + "there is an already commited field identified as " + byTypeAndType.getIdentifier()
+        + " with the same name and type";
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/AnyDocPartWithMissedDocPartIndexStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/AnyDocPartWithMissedDocPartIndexStrategy.java
@@ -19,7 +19,8 @@
 package com.torodb.metainfo.cache.mvcc.merge.index;
 
 import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ParentDescriptionFun;
 
 
 /**
@@ -46,7 +47,7 @@ public class AnyDocPartWithMissedDocPartIndexStrategy implements IndexPartialStr
   }
 
   private String getErrorMessage(
-      ExecutionResult.ParentDescriptionFun<ImmutableMetaCollection> parentDescFun,
+      ParentDescriptionFun<ImmutableMetaCollection> parentDescFun,
       IndexContext context) {
     String conflictingDocPart = context.getUncommitedParent()
         .getAnyDocPartWithMissedDocPartIndex(

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/AnyDocPartWithMissedDocPartIndexStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/AnyDocPartWithMissedDocPartIndexStrategy.java
@@ -1,0 +1,65 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.index;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+
+
+/**
+ *
+ */
+public class AnyDocPartWithMissedDocPartIndexStrategy implements IndexPartialStrategy {
+
+  @Override
+  public boolean appliesTo(IndexContext context) {
+    return context.getUncommitedParent().getAnyDocPartWithMissedDocPartIndex(
+        context.getCommitedParent(),
+        context.getChanged()
+    ).isPresent();
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaCollection> execute(IndexContext context,
+      ImmutableMetaCollection.Builder parentBuilder) throws IllegalArgumentException {
+
+    return ExecutionResult.error(
+        getClass(),
+        parentDescFun -> getErrorMessage(parentDescFun, context)
+    );
+  }
+
+  private String getErrorMessage(
+      ExecutionResult.ParentDescriptionFun<ImmutableMetaCollection> parentDescFun,
+      IndexContext context) {
+    String conflictingDocPart = context.getUncommitedParent()
+        .getAnyDocPartWithMissedDocPartIndex(
+            context.getCommitedParent(),
+            context.getChanged()
+        ).map(Object::toString)
+        .orElse("unknown");
+
+    String parentDesc = parentDescFun.apply(context.getCommitedParent());
+
+    return "There should be a doc part index on " + parentDesc + "." + conflictingDocPart + " "
+        + "associated only with new index " + context.getChanged() + " that has not been "
+        + "created.";
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/ConflictingIndexStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/ConflictingIndexStrategy.java
@@ -1,0 +1,99 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.index;
+
+import com.torodb.core.transaction.metainf.ChangedElement;
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection.Builder;
+import com.torodb.core.transaction.metainf.ImmutableMetaIndex;
+import com.torodb.core.transaction.metainf.MetaElementState;
+import com.torodb.core.transaction.metainf.MetaIndex;
+import com.torodb.core.transaction.metainf.MutableMetaCollection;
+import com.torodb.core.transaction.metainf.MutableMetaIndex;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+
+import java.util.Optional;
+
+
+/**
+ *
+ */
+public class ConflictingIndexStrategy implements IndexPartialStrategy {
+
+  @Override
+  public boolean appliesTo(IndexContext context) {
+    return getAnyConflictingIndex(context).isPresent();
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaCollection> execute(
+      IndexContext context,
+      Builder parentBuilder) throws IllegalArgumentException {
+    
+    return ExecutionResult.error(
+        getClass(),
+        parentDescFun -> getErrorMessage(parentDescFun, context)
+    );
+  }
+
+  private String getErrorMessage(
+      ExecutionResult.ParentDescriptionFun<ImmutableMetaCollection> parentDescFun,
+      IndexContext context) {
+    String parentDesc = parentDescFun.apply(context.getCommitedParent());
+    ImmutableMetaIndex byName = context.getCommitedParent()
+        .getMetaIndexByName(context.getChanged().getName());
+    return "There is a previous index on " + parentDesc + "." + byName + " that conflicts with "
+        + "new index " + parentDesc + '.' + context.getChanged();
+  }
+
+  public static Optional<ImmutableMetaIndex> getAnyConflictingIndex(IndexContext ctx) {
+    MutableMetaCollection uncmtCol = ctx.getUncommitedParent();
+    ImmutableMetaCollection cmtCol = ctx.getCommitedParent();
+    MutableMetaIndex newIndex = ctx.getChanged();
+
+    Optional<ImmutableMetaIndex> result = cmtCol.streamContainedMetaIndexes()
+        .filter(index -> index.isMatch(newIndex) && uncmtCol.streamModifiedMetaIndexes()
+            .noneMatch(modifiedIndex -> modifiedIndex.getChange() == MetaElementState.REMOVED
+                && modifiedIndex.getElement().getName().equals(index.getName())))
+        .findAny();
+
+    //gortiz: It is very difficult to read the stream above. I am temporally adding this
+    //new sentence that should be equivalent
+    assert result.orElse(null) == cmtCol.streamContainedMetaIndexes()
+        .filter(oldIndex -> oldIndex.isMatch(newIndex))
+        .filter(oldIndex -> !hasBeenRemoved(uncmtCol, oldIndex))
+        .findAny()
+        .orElse(null);
+
+    return result;
+  }
+
+  /**
+   * Returns true iff the given index has been removed on the given mutable collection.
+   */
+  private static boolean hasBeenRemoved(MutableMetaCollection newCol, MetaIndex oldIndex) {
+    Optional<ChangedElement<MutableMetaIndex>> modifiedIndex = newCol.getModifiedMetaIndexByName(
+        oldIndex.getName());
+    if (!modifiedIndex.isPresent()) {
+      return false;
+    }
+    return modifiedIndex.get().getChange() == MetaElementState.REMOVED;
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/ConflictingIndexStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/ConflictingIndexStrategy.java
@@ -26,7 +26,8 @@ import com.torodb.core.transaction.metainf.MetaElementState;
 import com.torodb.core.transaction.metainf.MetaIndex;
 import com.torodb.core.transaction.metainf.MutableMetaCollection;
 import com.torodb.core.transaction.metainf.MutableMetaIndex;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ParentDescriptionFun;
 
 import java.util.Optional;
 
@@ -53,7 +54,7 @@ public class ConflictingIndexStrategy implements IndexPartialStrategy {
   }
 
   private String getErrorMessage(
-      ExecutionResult.ParentDescriptionFun<ImmutableMetaCollection> parentDescFun,
+      ParentDescriptionFun<ImmutableMetaCollection> parentDescFun,
       IndexContext context) {
     String parentDesc = parentDescFun.apply(context.getCommitedParent());
     ImmutableMetaIndex byName = context.getCommitedParent()

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/IndexChildrenStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/IndexChildrenStrategy.java
@@ -22,15 +22,13 @@ import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
 import com.torodb.core.transaction.metainf.ImmutableMetaIndex;
 import com.torodb.core.transaction.metainf.MutableMetaIndex;
 import com.torodb.metainfo.cache.mvcc.merge.ChildrenMergePartialStrategy;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
 import com.torodb.metainfo.cache.mvcc.merge.index.field.IndexFieldContext;
 import com.torodb.metainfo.cache.mvcc.merge.index.field.IndexFieldMergeStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ParentDescriptionFun;
 
 import java.util.stream.Stream;
 
-/**
- *
- */
 public class IndexChildrenStrategy extends ChildrenMergePartialStrategy<ImmutableMetaCollection,
     MutableMetaIndex, ImmutableMetaCollection.Builder, IndexContext, ImmutableMetaIndex.Builder,
     ImmutableMetaIndex>
@@ -68,7 +66,7 @@ public class IndexChildrenStrategy extends ChildrenMergePartialStrategy<Immutabl
 
   @Override
   protected String describeChanged(
-      ExecutionResult.ParentDescriptionFun<ImmutableMetaCollection> parentDescFun,
+      ParentDescriptionFun<ImmutableMetaCollection> parentDescFun,
       ImmutableMetaCollection parent, ImmutableMetaIndex immutableSelf) {
     return parentDescFun.apply(parent) + '.' + immutableSelf.getName();
   }

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/IndexChildrenStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/IndexChildrenStrategy.java
@@ -1,0 +1,76 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.index;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
+import com.torodb.core.transaction.metainf.ImmutableMetaIndex;
+import com.torodb.core.transaction.metainf.MutableMetaIndex;
+import com.torodb.metainfo.cache.mvcc.merge.ChildrenMergePartialStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.index.field.IndexFieldContext;
+import com.torodb.metainfo.cache.mvcc.merge.index.field.IndexFieldMergeStrategy;
+
+import java.util.stream.Stream;
+
+/**
+ *
+ */
+public class IndexChildrenStrategy extends ChildrenMergePartialStrategy<ImmutableMetaCollection,
+    MutableMetaIndex, ImmutableMetaCollection.Builder, IndexContext, ImmutableMetaIndex.Builder,
+    ImmutableMetaIndex>
+    implements IndexPartialStrategy {
+
+  private final IndexFieldMergeStrategy fieldMergeStrategy = new IndexFieldMergeStrategy();
+
+  @Override
+  public boolean appliesTo(IndexContext context) {
+    return getCommitedByName(context) != null;
+  }
+
+  @Override
+  protected ImmutableMetaIndex.Builder createSelfBuilder(IndexContext context) {
+    ImmutableMetaIndex oldByName = getCommitedByName(context);
+    assert oldByName != null;
+
+    return new ImmutableMetaIndex.Builder(oldByName);
+  }
+
+  @Override
+  protected Stream<ExecutionResult<ImmutableMetaIndex>> streamChildResults(IndexContext context,
+      ImmutableMetaIndex.Builder selfBuilder) {
+    ImmutableMetaIndex oldVersion = getCommitedByName(context);
+    return context.getChanged().streamAddedMetaIndexFields()
+        .map(indexField -> new IndexFieldContext(oldVersion, indexField))
+        .map(ctx -> fieldMergeStrategy.execute(ctx, selfBuilder));
+  }
+
+  @Override
+  protected void changeParent(ImmutableMetaCollection.Builder parentBuilder,
+      ImmutableMetaIndex.Builder selfBuilder) {
+    parentBuilder.put(selfBuilder);
+  }
+
+  @Override
+  protected String describeChanged(
+      ExecutionResult.ParentDescriptionFun<ImmutableMetaCollection> parentDescFun,
+      ImmutableMetaCollection parent, ImmutableMetaIndex immutableSelf) {
+    return parentDescFun.apply(parent) + '.' + immutableSelf.getName();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/IndexContext.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/IndexContext.java
@@ -1,0 +1,44 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.index;
+
+import com.torodb.core.transaction.metainf.ChangedElement;
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
+import com.torodb.core.transaction.metainf.MetaElementState;
+import com.torodb.core.transaction.metainf.MutableMetaCollection;
+import com.torodb.core.transaction.metainf.MutableMetaIndex;
+import com.torodb.metainfo.cache.mvcc.merge.DefaultMergeContext;
+
+/**
+ *
+ */
+public class IndexContext
+    extends DefaultMergeContext<ImmutableMetaCollection, MutableMetaIndex, MutableMetaCollection> {
+
+  public IndexContext(ImmutableMetaCollection commitedParent, MutableMetaIndex changed,
+      MetaElementState change, MutableMetaCollection uncommitedParent) {
+    super(commitedParent, changed, change, uncommitedParent);
+  }
+
+  public IndexContext(ImmutableMetaCollection commitedParent,
+      ChangedElement<MutableMetaIndex> changed, MutableMetaCollection uncommitedParent) {
+    super(commitedParent, changed, uncommitedParent);
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/IndexContext.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/IndexContext.java
@@ -23,13 +23,13 @@ import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
 import com.torodb.core.transaction.metainf.MetaElementState;
 import com.torodb.core.transaction.metainf.MutableMetaCollection;
 import com.torodb.core.transaction.metainf.MutableMetaIndex;
-import com.torodb.metainfo.cache.mvcc.merge.DefaultMergeContext;
+import com.torodb.metainfo.cache.mvcc.merge.ExtendedMergeContext;
 
 /**
  *
  */
 public class IndexContext
-    extends DefaultMergeContext<ImmutableMetaCollection, MutableMetaIndex, MutableMetaCollection> {
+    extends ExtendedMergeContext<ImmutableMetaCollection, MutableMetaIndex, MutableMetaCollection> {
 
   public IndexContext(ImmutableMetaCollection commitedParent, MutableMetaIndex changed,
       MetaElementState change, MutableMetaCollection uncommitedParent) {

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/IndexMergeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/IndexMergeStrategy.java
@@ -24,14 +24,11 @@ import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
 import com.torodb.core.transaction.metainf.ImmutableMetaCollection.Builder;
 import com.torodb.core.transaction.metainf.MutableMetaIndex;
 import com.torodb.metainfo.cache.mvcc.merge.ByStateStrategyPicker;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
 import com.torodb.metainfo.cache.mvcc.merge.FirstToApplyStrategyPicker;
 import com.torodb.metainfo.cache.mvcc.merge.MergeStrategy;
 import com.torodb.metainfo.cache.mvcc.merge.MergeStrategyPicker;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
 
-/**
- *
- */
 public class IndexMergeStrategy
     implements MergeStrategy<ImmutableMetaCollection, MutableMetaIndex, Builder, IndexContext> {
 

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/IndexMergeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/IndexMergeStrategy.java
@@ -1,0 +1,84 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.index;
+
+
+import com.google.common.collect.Lists;
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection.Builder;
+import com.torodb.core.transaction.metainf.MutableMetaIndex;
+import com.torodb.metainfo.cache.mvcc.merge.ByStateStrategyPicker;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.FirstToApplyStrategyPicker;
+import com.torodb.metainfo.cache.mvcc.merge.MergeStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.MergeStrategyPicker;
+
+/**
+ *
+ */
+public class IndexMergeStrategy
+    implements MergeStrategy<ImmutableMetaCollection, MutableMetaIndex, Builder, IndexContext> {
+
+  @SuppressWarnings("checkstyle:LineLength")
+  private final MergeStrategyPicker<ImmutableMetaCollection, MutableMetaIndex, Builder, IndexContext> delegate;
+
+  public IndexMergeStrategy() {
+    this.delegate = new ByStateStrategyPicker<>(
+        createOnAddStrategy(),
+        createOnModifyStrategy(),
+        createOnRemoveStrategy()
+    );
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaCollection> execute(IndexContext ctx, Builder parentBuilder) {
+    return delegate.pick(ctx)
+        .execute(ctx, parentBuilder);
+  }
+
+  @SuppressWarnings("checkstyle:LineLength")
+  private static MergeStrategyPicker<ImmutableMetaCollection, MutableMetaIndex, Builder, IndexContext> createOnAddStrategy() {
+    return new FirstToApplyStrategyPicker<>(Lists.newArrayList(
+        new ConflictingIndexStrategy(),
+        new AnyDocPartWithMissedDocPartIndexStrategy(),
+        new NewIndexStrategy(),
+        new IndexChildrenStrategy()
+    ));
+  }
+
+  @SuppressWarnings("checkstyle:LineLength")
+  private static MergeStrategyPicker<ImmutableMetaCollection, MutableMetaIndex, Builder, IndexContext> createOnModifyStrategy() {
+    return createOnAddStrategy();
+  }
+
+  @SuppressWarnings("checkstyle:LineLength")
+  private static MergeStrategyPicker<ImmutableMetaCollection, MutableMetaIndex, Builder, IndexContext> createOnRemoveStrategy() {
+    return new FirstToApplyStrategyPicker<>(Lists.newArrayList(
+        new OrphanDocPartIndexStrategy(),
+        new NotExistentIndexStrategy()
+    ), IndexMergeStrategy::deleteIndex);
+  }
+
+  private static ExecutionResult<ImmutableMetaCollection> deleteIndex(
+      IndexContext ctx, Builder parentBuilder) {
+    parentBuilder.remove(ctx.getChanged());
+    return ExecutionResult.success();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/IndexPartialStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/IndexPartialStrategy.java
@@ -1,0 +1,42 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.index;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection.Builder;
+import com.torodb.core.transaction.metainf.ImmutableMetaIndex;
+import com.torodb.core.transaction.metainf.MutableMetaIndex;
+import com.torodb.metainfo.cache.mvcc.merge.PartialMergeStrategy;
+
+import javax.annotation.Nullable;
+
+
+/**
+ *
+ */
+interface IndexPartialStrategy extends
+    PartialMergeStrategy<ImmutableMetaCollection, MutableMetaIndex, Builder, IndexContext> {
+
+  @Nullable
+  public default ImmutableMetaIndex getCommitedByName(IndexContext context) {
+    return context.getCommitedParent()
+        .getMetaIndexByName(context.getChanged().getName());
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/NewIndexStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/NewIndexStrategy.java
@@ -1,0 +1,41 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.index;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+
+/**
+ *
+ */
+public class NewIndexStrategy implements IndexPartialStrategy {
+
+  @Override
+  public boolean appliesTo(IndexContext context) {
+    return getCommitedByName(context) == null;
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaCollection> execute(IndexContext context,
+      ImmutableMetaCollection.Builder parentBuilder) throws IllegalArgumentException {
+    parentBuilder.put(context.getChanged().immutableCopy());
+    return ExecutionResult.success();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/NewIndexStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/NewIndexStrategy.java
@@ -19,10 +19,10 @@
 package com.torodb.metainfo.cache.mvcc.merge.index;
 
 import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
 
 /**
- *
+ * The strategy used when there is no commited collection with the same name.
  */
 public class NewIndexStrategy implements IndexPartialStrategy {
 

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/NotExistentIndexStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/NotExistentIndexStrategy.java
@@ -1,0 +1,51 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.index;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection.Builder;
+import com.torodb.core.transaction.metainf.MetaElementState;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+
+/**
+ * A partial strategy that applies when an index is being removed but it is not found on the
+ * commited collection.
+ *
+ * <p/>This can happen when an index is created and removed on the same transaction or when
+ * merging a transaction that removes an index that has been already removed by a concurrent
+ * transaction that has been commited after this one is created but before it is commited.
+ */
+class NotExistentIndexStrategy implements IndexPartialStrategy {
+
+  @Override
+  public boolean appliesTo(IndexContext context) {
+    MetaElementState change = context.getChange();
+    if (change != MetaElementState.REMOVED) {
+      return false;
+    }
+    return getCommitedByName(context) == null;
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaCollection> execute(IndexContext context,
+      Builder parentBuilder) throws IllegalArgumentException {
+    return ExecutionResult.success();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/NotExistentIndexStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/NotExistentIndexStrategy.java
@@ -21,7 +21,7 @@ package com.torodb.metainfo.cache.mvcc.merge.index;
 import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
 import com.torodb.core.transaction.metainf.ImmutableMetaCollection.Builder;
 import com.torodb.core.transaction.metainf.MetaElementState;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
 
 /**
  * A partial strategy that applies when an index is being removed but it is not found on the

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/OrphanDocPartIndexStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/OrphanDocPartIndexStrategy.java
@@ -1,0 +1,68 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.index;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
+import com.torodb.core.transaction.metainf.ImmutableMetaIndex;
+import com.torodb.core.transaction.metainf.MetaIdentifiedDocPartIndex;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+
+import java.util.Optional;
+
+/**
+ *
+ */
+public class OrphanDocPartIndexStrategy implements IndexPartialStrategy {
+
+  @Override
+  public boolean appliesTo(IndexContext context) {
+    return getOrphan(context).isPresent();
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaCollection> execute(IndexContext context,
+      ImmutableMetaCollection.Builder parentBuilder) throws IllegalArgumentException {
+
+    return ExecutionResult.error(
+        getClass(),
+        parentDescFun -> getErrorMessage(parentDescFun, context)
+    );
+  }
+
+  private String getErrorMessage(
+      ExecutionResult.ParentDescriptionFun<ImmutableMetaCollection> parentDescFun,
+      IndexContext context) {
+    String parentDesc = parentDescFun.apply(context.getCommitedParent());
+    ImmutableMetaIndex byName = context.getCommitedParent()
+        .getMetaIndexByName(context.getChanged().getName());
+    String orphan = getOrphan(context)
+        .map(MetaIdentifiedDocPartIndex::getIdentifier)
+        .orElse("unknown");
+    return "There is a previous doc part index on " + parentDesc + "." + orphan + " associated "
+        + "only with removed index " + context.getChanged() + " that has not been deleted.";
+  }
+
+  private Optional<? extends MetaIdentifiedDocPartIndex> getOrphan(IndexContext context) {
+    return context.getUncommitedParent().getAnyOrphanDocPartIndex(
+        context.getCommitedParent(),
+        context.getChanged()
+    );
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/OrphanDocPartIndexStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/OrphanDocPartIndexStrategy.java
@@ -19,15 +19,12 @@
 package com.torodb.metainfo.cache.mvcc.merge.index;
 
 import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
-import com.torodb.core.transaction.metainf.ImmutableMetaIndex;
 import com.torodb.core.transaction.metainf.MetaIdentifiedDocPartIndex;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ParentDescriptionFun;
 
 import java.util.Optional;
 
-/**
- *
- */
 public class OrphanDocPartIndexStrategy implements IndexPartialStrategy {
 
   @Override
@@ -46,11 +43,9 @@ public class OrphanDocPartIndexStrategy implements IndexPartialStrategy {
   }
 
   private String getErrorMessage(
-      ExecutionResult.ParentDescriptionFun<ImmutableMetaCollection> parentDescFun,
+      ParentDescriptionFun<ImmutableMetaCollection> parentDescFun,
       IndexContext context) {
     String parentDesc = parentDescFun.apply(context.getCommitedParent());
-    ImmutableMetaIndex byName = context.getCommitedParent()
-        .getMetaIndexByName(context.getChanged().getName());
     String orphan = getOrphan(context)
         .map(MetaIdentifiedDocPartIndex::getIdentifier)
         .orElse("unknown");

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/IndexFieldContext.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/IndexFieldContext.java
@@ -21,12 +21,12 @@ package com.torodb.metainfo.cache.mvcc.merge.index.field;
 import com.torodb.core.transaction.metainf.ImmutableMetaIndex;
 import com.torodb.core.transaction.metainf.MetaElementState;
 import com.torodb.core.transaction.metainf.MetaIndexField;
-import com.torodb.metainfo.cache.mvcc.merge.PojoMergeContext;
+import com.torodb.metainfo.cache.mvcc.merge.DefaultMergeContext;
 
 /**
  *
  */
-public class IndexFieldContext extends PojoMergeContext<ImmutableMetaIndex, MetaIndexField> {
+public class IndexFieldContext extends DefaultMergeContext<ImmutableMetaIndex, MetaIndexField> {
 
   public IndexFieldContext(ImmutableMetaIndex commitedParent, MetaIndexField changed) {
     super(commitedParent, changed, MetaElementState.ADDED);

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/IndexFieldContext.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/IndexFieldContext.java
@@ -1,0 +1,35 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.index.field;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaIndex;
+import com.torodb.core.transaction.metainf.MetaElementState;
+import com.torodb.core.transaction.metainf.MetaIndexField;
+import com.torodb.metainfo.cache.mvcc.merge.PojoMergeContext;
+
+/**
+ *
+ */
+public class IndexFieldContext extends PojoMergeContext<ImmutableMetaIndex, MetaIndexField> {
+
+  public IndexFieldContext(ImmutableMetaIndex commitedParent, MetaIndexField changed) {
+    super(commitedParent, changed, MetaElementState.ADDED);
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/IndexFieldMergeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/IndexFieldMergeStrategy.java
@@ -1,0 +1,54 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.index.field;
+
+import com.google.common.collect.Lists;
+import com.torodb.core.transaction.metainf.ImmutableMetaIndex;
+import com.torodb.core.transaction.metainf.MetaIndexField;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.FirstToApplyStrategyPicker;
+import com.torodb.metainfo.cache.mvcc.merge.MergeStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.MergeStrategyPicker;
+
+/**
+ *
+ */
+public class IndexFieldMergeStrategy implements MergeStrategy<ImmutableMetaIndex, MetaIndexField,
+    ImmutableMetaIndex.Builder, IndexFieldContext> {
+
+  @SuppressWarnings("checkstyle:LineLength")
+  private final MergeStrategyPicker<ImmutableMetaIndex, MetaIndexField, ImmutableMetaIndex.Builder, IndexFieldContext> delegate;
+
+  public IndexFieldMergeStrategy() {
+    this.delegate = new FirstToApplyStrategyPicker<>(Lists.newArrayList(
+        new NewIndexFieldStrategy(),
+        new SamePositionOtherFieldNameStrategy(),
+        new SamePositionOtherRefStrategy(),
+        new SameRefAndNameOtherPositionStrategy()
+    ));
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaIndex> execute(IndexFieldContext context,
+      ImmutableMetaIndex.Builder parentBuilder) {
+    return delegate.pick(context)
+        .execute(context, parentBuilder);
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/IndexFieldMergeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/IndexFieldMergeStrategy.java
@@ -21,14 +21,11 @@ package com.torodb.metainfo.cache.mvcc.merge.index.field;
 import com.google.common.collect.Lists;
 import com.torodb.core.transaction.metainf.ImmutableMetaIndex;
 import com.torodb.core.transaction.metainf.MetaIndexField;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
 import com.torodb.metainfo.cache.mvcc.merge.FirstToApplyStrategyPicker;
 import com.torodb.metainfo.cache.mvcc.merge.MergeStrategy;
 import com.torodb.metainfo.cache.mvcc.merge.MergeStrategyPicker;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
 
-/**
- *
- */
 public class IndexFieldMergeStrategy implements MergeStrategy<ImmutableMetaIndex, MetaIndexField,
     ImmutableMetaIndex.Builder, IndexFieldContext> {
 

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/IndexFieldPartialStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/IndexFieldPartialStrategy.java
@@ -1,0 +1,47 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.index.field;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaIndex;
+import com.torodb.core.transaction.metainf.MetaIndexField;
+import com.torodb.metainfo.cache.mvcc.merge.PartialMergeStrategy;
+
+import javax.annotation.Nullable;
+
+/**
+ *
+ */
+public interface IndexFieldPartialStrategy extends PartialMergeStrategy<ImmutableMetaIndex,
+    MetaIndexField, ImmutableMetaIndex.Builder, IndexFieldContext> {
+
+  @Nullable
+  public default MetaIndexField getCommitedByPosition(IndexFieldContext context) {
+    MetaIndexField changed = context.getChanged();
+    return context.getCommitedParent().getMetaIndexFieldByPosition(changed.getPosition());
+  }
+
+  @Nullable
+  public default MetaIndexField getCommitedByNameAndRef(IndexFieldContext context) {
+    MetaIndexField changed = context.getChanged();
+    return context.getCommitedParent().getMetaIndexFieldByTableRefAndName(
+        changed.getTableRef(),
+        changed.getFieldName());
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/NewIndexFieldStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/NewIndexFieldStrategy.java
@@ -1,0 +1,41 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.index.field;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaIndex;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+
+/**
+ *
+ */
+public class NewIndexFieldStrategy implements IndexFieldPartialStrategy {
+
+  @Override
+  public boolean appliesTo(IndexFieldContext context) {
+    return getCommitedByNameAndRef(context) == null && getCommitedByPosition(context) != null;
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaIndex> execute(IndexFieldContext context,
+      ImmutableMetaIndex.Builder parentBuilder) throws IllegalArgumentException {
+    parentBuilder.add(context.getChanged().immutableCopy());
+    return ExecutionResult.success();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/NewIndexFieldStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/NewIndexFieldStrategy.java
@@ -19,7 +19,7 @@
 package com.torodb.metainfo.cache.mvcc.merge.index.field;
 
 import com.torodb.core.transaction.metainf.ImmutableMetaIndex;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
 
 /**
  *

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/SamePositionOtherFieldNameStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/SamePositionOtherFieldNameStrategy.java
@@ -1,0 +1,65 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.index.field;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaIndex;
+import com.torodb.core.transaction.metainf.ImmutableMetaIndex.Builder;
+import com.torodb.core.transaction.metainf.MetaIndexField;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+
+
+
+
+/**
+ *
+ */
+class SamePositionOtherFieldNameStrategy implements IndexFieldPartialStrategy {
+
+  @Override
+  public boolean appliesTo(IndexFieldContext context) {
+    MetaIndexField byPos = getCommitedByPosition(context);
+    return byPos != null && !byPos.getFieldName().equals(context.getChanged().getFieldName());
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaIndex> execute(
+      IndexFieldContext context,
+      Builder parentBuilder) throws IllegalArgumentException {
+    return ExecutionResult.error(
+        getClass(),
+        parentDescFun -> getErrorMessage(context, parentDescFun)
+    );
+  }
+
+  private String getErrorMessage(IndexFieldContext context,
+      ParentDescriptionFun<ImmutableMetaIndex> parentDescription) {
+    MetaIndexField changed = context.getChanged();
+    MetaIndexField byPos = getCommitedByPosition(context);
+    assert byPos != null;
+    String parent = parentDescription.apply(context.getCommitedParent());
+    String describeChange = context.getChange().toString();
+
+    return "The index " + parent + " contains a new field with name " + changed.getFieldName() + " "
+        + "on " + changed.getTableRef() + " at position " + changed.getPosition() + " that cannot "
+        + "be " + describeChange + " because there is an already commited field with the position "
+        + "whose name is " + byPos.getFieldName();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/SamePositionOtherFieldNameStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/SamePositionOtherFieldNameStrategy.java
@@ -21,8 +21,8 @@ package com.torodb.metainfo.cache.mvcc.merge.index.field;
 import com.torodb.core.transaction.metainf.ImmutableMetaIndex;
 import com.torodb.core.transaction.metainf.ImmutableMetaIndex.Builder;
 import com.torodb.core.transaction.metainf.MetaIndexField;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ParentDescriptionFun;
 
 
 

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/SamePositionOtherRefStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/SamePositionOtherRefStrategy.java
@@ -21,8 +21,8 @@ package com.torodb.metainfo.cache.mvcc.merge.index.field;
 import com.torodb.core.transaction.metainf.ImmutableMetaIndex;
 import com.torodb.core.transaction.metainf.ImmutableMetaIndex.Builder;
 import com.torodb.core.transaction.metainf.MetaIndexField;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ParentDescriptionFun;
 
 
 

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/SamePositionOtherRefStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/SamePositionOtherRefStrategy.java
@@ -1,0 +1,64 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.index.field;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaIndex;
+import com.torodb.core.transaction.metainf.ImmutableMetaIndex.Builder;
+import com.torodb.core.transaction.metainf.MetaIndexField;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+
+
+
+/**
+ *
+ */
+class SamePositionOtherRefStrategy implements IndexFieldPartialStrategy {
+
+  @Override
+  public boolean appliesTo(IndexFieldContext context) {
+    MetaIndexField byPos = getCommitedByPosition(context);
+    return byPos != null && !byPos.getTableRef().equals(context.getChanged().getTableRef());
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaIndex> execute(
+      IndexFieldContext context,
+      Builder parentBuilder) throws IllegalArgumentException {
+    return ExecutionResult.error(
+        getClass(),
+        parentDescFun -> getErrorMessage(context, parentDescFun)
+    );
+  }
+
+  private String getErrorMessage(IndexFieldContext context,
+      ParentDescriptionFun<ImmutableMetaIndex> parentDescription) {
+    MetaIndexField changed = context.getChanged();
+    MetaIndexField byPos = getCommitedByPosition(context);
+    assert byPos != null;
+    String parent = parentDescription.apply(context.getCommitedParent());
+    String describeChange = context.getChange().toString();
+
+    return "The index " + parent + " contains a new field with name " + changed.getFieldName() + " "
+        + "on " + changed.getTableRef() + " at position " + changed.getPosition() + " that cannot "
+        + "be " + describeChange + " because there is an already commited field with the position "
+        + "whose table ref is " + byPos.getTableRef();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/SameRefAndNameOtherPositionStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/SameRefAndNameOtherPositionStrategy.java
@@ -21,8 +21,8 @@ package com.torodb.metainfo.cache.mvcc.merge.index.field;
 import com.torodb.core.transaction.metainf.ImmutableMetaIndex;
 import com.torodb.core.transaction.metainf.ImmutableMetaIndex.Builder;
 import com.torodb.core.transaction.metainf.MetaIndexField;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ParentDescriptionFun;
 
 
 

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/SameRefAndNameOtherPositionStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/SameRefAndNameOtherPositionStrategy.java
@@ -1,0 +1,65 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.index.field;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaIndex;
+import com.torodb.core.transaction.metainf.ImmutableMetaIndex.Builder;
+import com.torodb.core.transaction.metainf.MetaIndexField;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+
+
+
+/**
+ *
+ */
+class SameRefAndNameOtherPositionStrategy implements IndexFieldPartialStrategy {
+
+  @Override
+  public boolean appliesTo(IndexFieldContext context) {
+    MetaIndexField byNameAndRef = getCommitedByNameAndRef(context);
+    return byNameAndRef != null
+        && byNameAndRef.getPosition() != context.getChanged().getPosition();
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaIndex> execute(
+      IndexFieldContext context,
+      Builder parentBuilder) throws IllegalArgumentException {
+    return ExecutionResult.error(
+        getClass(),
+        parentDescFun -> getErrorMessage(context, parentDescFun)
+    );
+  }
+
+  private String getErrorMessage(IndexFieldContext context,
+      ParentDescriptionFun<ImmutableMetaIndex> parentDescription) {
+    MetaIndexField changed = context.getChanged();
+    MetaIndexField byRefAndName = getCommitedByNameAndRef(context);
+    assert byRefAndName != null;
+    String parent = parentDescription.apply(context.getCommitedParent());
+    String describeChange = context.getChange().toString();
+
+    return "The index " + parent + " contains a new field with name " + changed.getFieldName() + " "
+        + "on " + changed.getTableRef() + " at position " + changed.getPosition() + " that cannot "
+        + "be " + describeChange + " because there is an already commited field with the same name "
+        + "and table ref whose position is " + byRefAndName.getPosition();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/column/IndexColumnCtx.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/column/IndexColumnCtx.java
@@ -1,0 +1,38 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.index.field.column;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaIdentifiedDocPartIndex;
+import com.torodb.core.transaction.metainf.MetaDocPartIndexColumn;
+import com.torodb.core.transaction.metainf.MetaElementState;
+import com.torodb.core.transaction.metainf.MetaIdentifiedDocPartIndex;
+import com.torodb.metainfo.cache.mvcc.merge.DefaultMergeContext;
+
+/**
+ *
+ */
+public class IndexColumnCtx extends DefaultMergeContext<ImmutableMetaIdentifiedDocPartIndex,
+    MetaDocPartIndexColumn, MetaIdentifiedDocPartIndex> {
+
+  public IndexColumnCtx(ImmutableMetaIdentifiedDocPartIndex commitedParent,
+      MetaDocPartIndexColumn changed, MetaIdentifiedDocPartIndex uncommitedParent) {
+    super(commitedParent, changed, MetaElementState.ADDED, uncommitedParent);
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/column/IndexColumnCtx.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/column/IndexColumnCtx.java
@@ -22,12 +22,12 @@ import com.torodb.core.transaction.metainf.ImmutableMetaIdentifiedDocPartIndex;
 import com.torodb.core.transaction.metainf.MetaDocPartIndexColumn;
 import com.torodb.core.transaction.metainf.MetaElementState;
 import com.torodb.core.transaction.metainf.MetaIdentifiedDocPartIndex;
-import com.torodb.metainfo.cache.mvcc.merge.DefaultMergeContext;
+import com.torodb.metainfo.cache.mvcc.merge.ExtendedMergeContext;
 
 /**
  *
  */
-public class IndexColumnCtx extends DefaultMergeContext<ImmutableMetaIdentifiedDocPartIndex,
+public class IndexColumnCtx extends ExtendedMergeContext<ImmutableMetaIdentifiedDocPartIndex,
     MetaDocPartIndexColumn, MetaIdentifiedDocPartIndex> {
 
   public IndexColumnCtx(ImmutableMetaIdentifiedDocPartIndex commitedParent,

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/column/IndexColumnMergeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/column/IndexColumnMergeStrategy.java
@@ -1,0 +1,54 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.index.field.column;
+
+import com.google.common.collect.Lists;
+import com.torodb.core.transaction.metainf.ImmutableMetaIdentifiedDocPartIndex;
+import com.torodb.core.transaction.metainf.ImmutableMetaIdentifiedDocPartIndex.Builder;
+import com.torodb.core.transaction.metainf.MetaDocPartIndexColumn;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.FirstToApplyStrategyPicker;
+import com.torodb.metainfo.cache.mvcc.merge.MergeStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.MergeStrategyPicker;
+
+/**
+ *
+ */
+public class IndexColumnMergeStrategy implements MergeStrategy<ImmutableMetaIdentifiedDocPartIndex,
+    MetaDocPartIndexColumn, Builder, IndexColumnCtx> {
+
+  @SuppressWarnings("checkstyle:LineLength")
+  private final MergeStrategyPicker<ImmutableMetaIdentifiedDocPartIndex, MetaDocPartIndexColumn, Builder, IndexColumnCtx> delegate;
+
+  public IndexColumnMergeStrategy() {
+    this.delegate = new FirstToApplyStrategyPicker<>(Lists.newArrayList(
+        new SameIdOtherPositionNameStrategy(),
+        new SamePositionOtherIdNameStrategy(),
+        new NewIndexColumnStrategy()
+    ));
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaIdentifiedDocPartIndex> execute(IndexColumnCtx context,
+      Builder parentBuilder) {
+    return delegate.pick(context)
+        .execute(context, parentBuilder);
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/column/IndexColumnMergeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/column/IndexColumnMergeStrategy.java
@@ -22,14 +22,11 @@ import com.google.common.collect.Lists;
 import com.torodb.core.transaction.metainf.ImmutableMetaIdentifiedDocPartIndex;
 import com.torodb.core.transaction.metainf.ImmutableMetaIdentifiedDocPartIndex.Builder;
 import com.torodb.core.transaction.metainf.MetaDocPartIndexColumn;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
 import com.torodb.metainfo.cache.mvcc.merge.FirstToApplyStrategyPicker;
 import com.torodb.metainfo.cache.mvcc.merge.MergeStrategy;
 import com.torodb.metainfo.cache.mvcc.merge.MergeStrategyPicker;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
 
-/**
- *
- */
 public class IndexColumnMergeStrategy implements MergeStrategy<ImmutableMetaIdentifiedDocPartIndex,
     MetaDocPartIndexColumn, Builder, IndexColumnCtx> {
 

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/column/IndexColumnPartialStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/column/IndexColumnPartialStrategy.java
@@ -1,0 +1,49 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.index.field.column;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaIdentifiedDocPartIndex;
+import com.torodb.core.transaction.metainf.ImmutableMetaIdentifiedDocPartIndex.Builder;
+import com.torodb.core.transaction.metainf.MetaDocPartIndexColumn;
+import com.torodb.metainfo.cache.mvcc.merge.PartialMergeStrategy;
+
+import javax.annotation.Nullable;
+
+/**
+ *
+ */
+public interface IndexColumnPartialStrategy extends PartialMergeStrategy<
+    ImmutableMetaIdentifiedDocPartIndex, MetaDocPartIndexColumn, Builder,
+    IndexColumnCtx> {
+
+  @Nullable
+  public default MetaDocPartIndexColumn getCommitedByPosition(IndexColumnCtx context) {
+    return context.getCommitedParent().getMetaDocPartIndexColumnByPosition(
+        context.getChanged().getPosition()
+    );
+  }
+
+  @Nullable
+  public default MetaDocPartIndexColumn getCommitedById(IndexColumnCtx context) {
+    return context.getCommitedParent().getMetaDocPartIndexColumnByIdentifier(
+        context.getChanged().getIdentifier()
+    );
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/column/NewIndexColumnStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/column/NewIndexColumnStrategy.java
@@ -1,0 +1,42 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.index.field.column;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaIdentifiedDocPartIndex;
+import com.torodb.core.transaction.metainf.ImmutableMetaIdentifiedDocPartIndex.Builder;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+
+/**
+ *
+ */
+public class NewIndexColumnStrategy implements IndexColumnPartialStrategy {
+
+  @Override
+  public boolean appliesTo(IndexColumnCtx context) {
+    return getCommitedById(context) == null && getCommitedByPosition(context) != null;
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaIdentifiedDocPartIndex> execute(IndexColumnCtx context,
+      Builder parentBuilder) throws IllegalArgumentException {
+    parentBuilder.add(context.getChanged().immutableCopy());
+    return ExecutionResult.success();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/column/NewIndexColumnStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/column/NewIndexColumnStrategy.java
@@ -20,7 +20,7 @@ package com.torodb.metainfo.cache.mvcc.merge.index.field.column;
 
 import com.torodb.core.transaction.metainf.ImmutableMetaIdentifiedDocPartIndex;
 import com.torodb.core.transaction.metainf.ImmutableMetaIdentifiedDocPartIndex.Builder;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
 
 /**
  *

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/column/SameIdOtherPositionNameStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/column/SameIdOtherPositionNameStrategy.java
@@ -20,8 +20,8 @@ package com.torodb.metainfo.cache.mvcc.merge.index.field.column;
 
 import com.torodb.core.transaction.metainf.ImmutableMetaIdentifiedDocPartIndex;
 import com.torodb.core.transaction.metainf.MetaDocPartIndexColumn;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ParentDescriptionFun;
 
 /**
  *

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/column/SameIdOtherPositionNameStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/column/SameIdOtherPositionNameStrategy.java
@@ -1,0 +1,60 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.index.field.column;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaIdentifiedDocPartIndex;
+import com.torodb.core.transaction.metainf.MetaDocPartIndexColumn;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+
+/**
+ *
+ */
+class SameIdOtherPositionNameStrategy implements IndexColumnPartialStrategy {
+
+  @Override
+  public boolean appliesTo(IndexColumnCtx context) {
+    MetaDocPartIndexColumn byId = getCommitedById(context);
+    return byId != null && byId.getPosition() != context.getChanged().getPosition();
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaIdentifiedDocPartIndex> execute(IndexColumnCtx context,
+      ImmutableMetaIdentifiedDocPartIndex.Builder parentBuilder) throws IllegalArgumentException {
+    return ExecutionResult.error(
+        getClass(),
+        parentDescFun -> getErrorMessage(context, parentDescFun)
+    );
+  }
+
+  private String getErrorMessage(IndexColumnCtx context,
+      ParentDescriptionFun<ImmutableMetaIdentifiedDocPartIndex> parentDescription) {
+    MetaDocPartIndexColumn changed = context.getChanged();
+    MetaDocPartIndexColumn byId = getCommitedById(context);
+    assert byId != null;
+    String parent = parentDescription.apply(context.getCommitedParent());
+    String describeChange = context.getChange().toString();
+
+    return "The index field " + parent + " contains indexes a column identified as "
+        + changed.getIdentifier() + " at position " + changed.getPosition() + " that cannot "
+        + "be " + describeChange + " because there is an already commited column with the same id "
+        + "at position " + byId.getPosition();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/column/SamePositionOtherIdNameStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/column/SamePositionOtherIdNameStrategy.java
@@ -1,0 +1,60 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.index.field.column;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaIdentifiedDocPartIndex;
+import com.torodb.core.transaction.metainf.MetaDocPartIndexColumn;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+
+/**
+ *
+ */
+class SamePositionOtherIdNameStrategy implements IndexColumnPartialStrategy {
+
+  @Override
+  public boolean appliesTo(IndexColumnCtx context) {
+    MetaDocPartIndexColumn byPos = getCommitedByPosition(context);
+    return byPos != null && !byPos.getIdentifier().equals(context.getChanged().getIdentifier());
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaIdentifiedDocPartIndex> execute(IndexColumnCtx context,
+      ImmutableMetaIdentifiedDocPartIndex.Builder parentBuilder) throws IllegalArgumentException {
+    return ExecutionResult.error(
+        getClass(),
+        parentDescFun -> getErrorMessage(context, parentDescFun)
+    );
+  }
+
+  private String getErrorMessage(IndexColumnCtx context,
+      ParentDescriptionFun<ImmutableMetaIdentifiedDocPartIndex> parentDescription) {
+    MetaDocPartIndexColumn changed = context.getChanged();
+    MetaDocPartIndexColumn byPos = getCommitedByPosition(context);
+    assert byPos != null;
+    String parent = parentDescription.apply(context.getCommitedParent());
+    String describeChange = context.getChange().toString();
+
+    return "The index field " + parent + " contains indexes a column identified as "
+        + changed.getIdentifier() + " at position " + changed.getPosition() + " that cannot "
+        + "be " + describeChange + " because at that position there is an already commited column "
+        + "whose identifier is " + byPos.getIdentifier();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/column/SamePositionOtherIdNameStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/index/field/column/SamePositionOtherIdNameStrategy.java
@@ -20,8 +20,8 @@ package com.torodb.metainfo.cache.mvcc.merge.index.field.column;
 
 import com.torodb.core.transaction.metainf.ImmutableMetaIdentifiedDocPartIndex;
 import com.torodb.core.transaction.metainf.MetaDocPartIndexColumn;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ParentDescriptionFun;
 
 /**
  *

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/result/ErrorExecutionResult.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/result/ErrorExecutionResult.java
@@ -1,0 +1,47 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.result;
+
+import java.util.Optional;
+
+/**
+ * A {@link ExecutionResult} that doesn't success.
+ */
+class ErrorExecutionResult<P, C> extends ExecutionResult<P> {
+  /**
+   * Returns the error message on a format that follow {@link MessageFormat} syntax, where
+   * the first argument is a text that identifies the parent and the second a text that identifies
+   * the changed element.
+   */
+  private final PrettyErrorMessageFactory<P> messageFactory;
+
+  public ErrorExecutionResult(String ruleId, InnerErrorMessageFactory<P> messageFactory) {
+    this.messageFactory = new PrettyErrorMessageFactory<>(ruleId, messageFactory);
+  }
+
+  @Override
+  public boolean isSuccess() {
+    return false;
+  }
+
+  @Override
+  public Optional<PrettyErrorMessageFactory<P>> getErrorMessageFactory() {
+    return Optional.of(messageFactory);
+  }
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/result/InnerErrorMessageFactory.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/result/InnerErrorMessageFactory.java
@@ -16,29 +16,22 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.torodb.metainfo.cache.mvcc.merge;
+package com.torodb.metainfo.cache.mvcc.merge.result;
 
-
-import java.util.Optional;
+import java.util.function.Function;
 
 /**
+ * A marker interface used to identify error factories.
  *
+ * <p>Objects of this class are wrapped by {@link PrettyErrorMessageFactory} to create the real
+ * error message factory that can be used to generate the error message with some context 
+ * information (like the rule id).
  */
-class SuccessExecutionResult<P> extends ExecutionResult<P> {
-
-  static final SuccessExecutionResult<?> INSTANCE = new SuccessExecutionResult<>();
-
-  private SuccessExecutionResult() {
-  }
+@FunctionalInterface
+public interface InnerErrorMessageFactory<P>
+    extends Function<ParentDescriptionFun<P>, String> {
 
   @Override
-  public boolean isSuccess() {
-    return true;
-  }
-
-  @Override
-  public Optional<PrettyErrorMessageFactory<P>> getErrorMessageFactory() {
-    return Optional.empty();
-  }
+  public String apply(ParentDescriptionFun<P> parentDescriptionFun);
 
 }

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/result/MapErrorExecutionResult.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/result/MapErrorExecutionResult.java
@@ -1,0 +1,49 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.result;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * A {@link ExecutionResult} that maps the error message to a delegate.
+ */
+class MapErrorExecutionResult<P1, P2> extends ExecutionResult<P2> {
+
+  private final ExecutionResult<P1> delegate;
+  private final Function<InnerErrorMessageFactory<P1>, InnerErrorMessageFactory<P2>> transformation;
+
+  MapErrorExecutionResult(ExecutionResult<P1> delegate,
+      Function<InnerErrorMessageFactory<P1>, InnerErrorMessageFactory<P2>> transformation) {
+    this.delegate = delegate;
+    this.transformation = transformation;
+  }
+
+  @Override
+  public boolean isSuccess() {
+    return delegate.isSuccess();
+  }
+
+  @Override
+  public Optional<PrettyErrorMessageFactory<P2>> getErrorMessageFactory() {
+    return delegate.getErrorMessageFactory()
+        .map(factory -> factory.transform(transformation));
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/result/ParentDescriptionFun.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/result/ParentDescriptionFun.java
@@ -16,34 +16,18 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.torodb.metainfo.cache.mvcc.merge;
+package com.torodb.metainfo.cache.mvcc.merge.result;
 
-import java.util.Optional;
 import java.util.function.Function;
 
 /**
- *
+ * A marker interface used to identify functions that describes elements of a given type.
+ * @param <P> the type that is described
  */
-class MapErrorExecutionResult<P1, P2> extends ExecutionResult<P2> {
-
-  private final ExecutionResult<P1> delegate;
-  private final Function<InnerErrorMessageFactory<P1>, InnerErrorMessageFactory<P2>> transformation;
-
-  public MapErrorExecutionResult(ExecutionResult<P1> delegate,
-      Function<InnerErrorMessageFactory<P1>, InnerErrorMessageFactory<P2>> transformation) {
-    this.delegate = delegate;
-    this.transformation = transformation;
-  }
+@FunctionalInterface
+public interface ParentDescriptionFun<P> extends Function<P, String> {
 
   @Override
-  public boolean isSuccess() {
-    return delegate.isSuccess();
-  }
-
-  @Override
-  public Optional<PrettyErrorMessageFactory<P2>> getErrorMessageFactory() {
-    return delegate.getErrorMessageFactory()
-        .map(factory -> factory.transform(transformation));
-  }
+  public String apply(P parent);
 
 }

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/result/PrettyErrorMessageFactory.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/result/PrettyErrorMessageFactory.java
@@ -1,0 +1,47 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.result;
+
+import java.util.function.Function;
+
+/**
+ * The function returned by {@link ExecutionResult#getErrorMessageFactory() } so the error text
+ * can be generated.
+ */
+public class PrettyErrorMessageFactory<P> implements Function<ParentDescriptionFun<P>, String> {
+
+  private final String ruleId;
+  private final InnerErrorMessageFactory<P> delegate;
+
+  public PrettyErrorMessageFactory(String ruleId, InnerErrorMessageFactory<P> delegate) {
+    this.ruleId = ruleId;
+    this.delegate = delegate;
+  }
+
+  @Override
+  public String apply(ParentDescriptionFun<P> parentDescriptionFun) {
+    return ruleId + ": " + delegate.apply(parentDescriptionFun);
+  }
+
+  public <P2> PrettyErrorMessageFactory<P2> transform(
+      Function<InnerErrorMessageFactory<P>, InnerErrorMessageFactory<P2>> transformation) {
+    return new PrettyErrorMessageFactory<>(ruleId, transformation.apply(delegate));
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/result/SuccessExecutionResult.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/result/SuccessExecutionResult.java
@@ -16,32 +16,31 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.torodb.metainfo.cache.mvcc.merge;
+package com.torodb.metainfo.cache.mvcc.merge.result;
+
 
 import java.util.Optional;
 
 /**
- *
+ * A {@link ExecutionResult} that has success and therefore {@link #isSuccess()} returns true and
+ * {@link #getErrorMessageFactory() } returns an empty optional.
+ * @param <P> The commited parent type.
  */
-class ErrorExecutionResult<P, C> extends ExecutionResult<P> {
-  /**
-   * Returns the error message on a format that follow {@link MessageFormat} syntax, where
-   * the first argument is a text that identifies the parent and the second a text that identifies
-   * the changed element.
-   */
-  private final ExecutionResult.PrettyErrorMessageFactory<P> messageFactory;
+class SuccessExecutionResult<P> extends ExecutionResult<P> {
 
-  public ErrorExecutionResult(String ruleId, InnerErrorMessageFactory<P> messageFactory) {
-    this.messageFactory = new PrettyErrorMessageFactory<>(ruleId, messageFactory);
+  static final SuccessExecutionResult<?> INSTANCE = new SuccessExecutionResult<>();
+
+  private SuccessExecutionResult() {
   }
 
   @Override
   public boolean isSuccess() {
-    return false;
+    return true;
   }
 
   @Override
   public Optional<PrettyErrorMessageFactory<P>> getErrorMessageFactory() {
-    return Optional.of(messageFactory);
+    return Optional.empty();
   }
+
 }

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/scalar/NewScalarStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/scalar/NewScalarStrategy.java
@@ -1,0 +1,43 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.scalar;
+
+
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart.Builder;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+
+/**
+ *
+ */
+class NewScalarStrategy implements ScalarPartialMergeStrategy {
+
+  @Override
+  public ExecutionResult<ImmutableMetaDocPart> execute(ScalarContext context, Builder parentBuilder)
+      throws IllegalArgumentException {
+    parentBuilder.put(context.getChanged().immutableCopy());
+    return ExecutionResult.success();
+  }
+
+  @Override
+  public boolean appliesTo(ScalarContext context) {
+    return getCommitedById(context) == null && getCommitedByType(context) == null;
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/scalar/NewScalarStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/scalar/NewScalarStrategy.java
@@ -21,7 +21,7 @@ package com.torodb.metainfo.cache.mvcc.merge.scalar;
 
 import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
 import com.torodb.core.transaction.metainf.ImmutableMetaDocPart.Builder;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
 
 /**
  *

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/scalar/SameIdOtherTypeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/scalar/SameIdOtherTypeStrategy.java
@@ -21,8 +21,8 @@ package com.torodb.metainfo.cache.mvcc.merge.scalar;
 import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
 import com.torodb.core.transaction.metainf.ImmutableMetaDocPart.Builder;
 import com.torodb.core.transaction.metainf.MetaScalar;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ParentDescriptionFun;
 
 
 /**

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/scalar/SameIdOtherTypeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/scalar/SameIdOtherTypeStrategy.java
@@ -1,0 +1,62 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.scalar;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart.Builder;
+import com.torodb.core.transaction.metainf.MetaScalar;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+
+
+/**
+ *
+ */
+class SameIdOtherTypeStrategy implements ScalarPartialMergeStrategy {
+
+  @Override
+  public boolean appliesTo(ScalarContext context) {
+    MetaScalar changed = context.getChanged();
+    MetaScalar byId = getCommitedById(context);
+    return byId != null && !byId.getType().equals(changed.getType());
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaDocPart> execute(ScalarContext context, Builder callback)
+      throws IllegalArgumentException {
+    return ExecutionResult.error(
+        getClass(),
+        parentDescFun -> getErrorMessage(parentDescFun, context)
+    );
+  }
+
+  private String getErrorMessage(
+      ParentDescriptionFun<ImmutableMetaDocPart> parentDescFun,
+      ScalarContext context) {
+    MetaScalar changed = context.getChanged();
+    MetaScalar byId = getCommitedById(context);
+    assert byId != null;
+    String parent = parentDescFun.apply(context.getCommitedParent());
+    
+    return "There is a previous meta scalar on " + parent + " whose identifier is "
+        + changed.getIdentifier() + " but its type is " + byId.getType() + ". The type of the "
+        + "new one is " + changed.getType();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/scalar/SameTypeOtherIdStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/scalar/SameTypeOtherIdStrategy.java
@@ -21,8 +21,8 @@ package com.torodb.metainfo.cache.mvcc.merge.scalar;
 import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
 import com.torodb.core.transaction.metainf.ImmutableMetaDocPart.Builder;
 import com.torodb.core.transaction.metainf.MetaScalar;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.result.ParentDescriptionFun;
 
 
 /**

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/scalar/SameTypeOtherIdStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/scalar/SameTypeOtherIdStrategy.java
@@ -1,0 +1,62 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.scalar;
+
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart.Builder;
+import com.torodb.core.transaction.metainf.MetaScalar;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult.ParentDescriptionFun;
+
+
+/**
+ *
+ */
+class SameTypeOtherIdStrategy implements ScalarPartialMergeStrategy {
+
+  @Override
+  public boolean appliesTo(ScalarContext context) {
+    MetaScalar changed = context.getChanged();
+    MetaScalar byType = getCommitedByType(context);
+    return byType != null && !byType.getIdentifier().equals(changed.getIdentifier());
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaDocPart> execute(ScalarContext context, Builder callback)
+      throws IllegalArgumentException {
+    return ExecutionResult.error(
+        getClass(),
+        parentDescFun -> getErrorMessage(parentDescFun, context)
+    );
+  }
+
+  private String getErrorMessage(
+      ParentDescriptionFun<ImmutableMetaDocPart> parentDescFun,
+      ScalarContext context) {
+    MetaScalar changed = context.getChanged();
+    MetaScalar byType = getCommitedByType(context);
+    assert byType != null;
+    String parent = parentDescFun.apply(context.getCommitedParent());
+
+    return "There is a previous meta scalar on " + parent + " whose type is "
+        + changed.getType() + " but its identifier is " + byType.getIdentifier()
+        + ". The identifier of the new one is " + changed.getIdentifier();
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/scalar/ScalarContext.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/scalar/ScalarContext.java
@@ -1,0 +1,42 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.scalar;
+
+import com.torodb.core.transaction.metainf.ChangedElement;
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
+import com.torodb.core.transaction.metainf.MetaElementState;
+import com.torodb.core.transaction.metainf.MetaScalar;
+import com.torodb.metainfo.cache.mvcc.merge.PojoMergeContext;
+
+/**
+ *
+ */
+public class ScalarContext extends PojoMergeContext<ImmutableMetaDocPart, MetaScalar> {
+
+  public ScalarContext(ImmutableMetaDocPart commitedParent, MetaScalar changed,
+      MetaElementState change) {
+    super(commitedParent, changed, change);
+  }
+
+  public ScalarContext(ImmutableMetaDocPart commitedParent,
+      ChangedElement<? extends MetaScalar> changed) {
+    super(commitedParent, changed);
+  }
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/scalar/ScalarContext.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/scalar/ScalarContext.java
@@ -22,12 +22,12 @@ import com.torodb.core.transaction.metainf.ChangedElement;
 import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
 import com.torodb.core.transaction.metainf.MetaElementState;
 import com.torodb.core.transaction.metainf.MetaScalar;
-import com.torodb.metainfo.cache.mvcc.merge.PojoMergeContext;
+import com.torodb.metainfo.cache.mvcc.merge.DefaultMergeContext;
 
 /**
  *
  */
-public class ScalarContext extends PojoMergeContext<ImmutableMetaDocPart, MetaScalar> {
+public class ScalarContext extends DefaultMergeContext<ImmutableMetaDocPart, MetaScalar> {
 
   public ScalarContext(ImmutableMetaDocPart commitedParent, MetaScalar changed,
       MetaElementState change) {

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/scalar/ScalarMergeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/scalar/ScalarMergeStrategy.java
@@ -1,0 +1,55 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.scalar;
+
+import com.google.common.collect.Lists;
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart.Builder;
+import com.torodb.core.transaction.metainf.MetaScalar;
+import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
+import com.torodb.metainfo.cache.mvcc.merge.FirstToApplyStrategyPicker;
+import com.torodb.metainfo.cache.mvcc.merge.MergeStrategy;
+import com.torodb.metainfo.cache.mvcc.merge.MergeStrategyPicker;
+
+/**
+ *
+ */
+public class ScalarMergeStrategy implements
+    MergeStrategy<ImmutableMetaDocPart, MetaScalar, Builder, ScalarContext> {
+
+  @SuppressWarnings("checkstyle:LineLength")
+  private final MergeStrategyPicker<ImmutableMetaDocPart, MetaScalar, Builder, ScalarContext> delegate;
+
+  public ScalarMergeStrategy() {
+    this.delegate = new FirstToApplyStrategyPicker<>(Lists.newArrayList(
+        new NewScalarStrategy(),
+        new SameTypeOtherIdStrategy(),
+        new SameIdOtherTypeStrategy()
+    ));
+  }
+
+  @Override
+  public ExecutionResult<ImmutableMetaDocPart> execute(
+      ScalarContext context, Builder parentBuilder) {
+    return delegate.pick(context)
+        .execute(context, parentBuilder);
+  }
+
+
+}

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/scalar/ScalarMergeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/scalar/ScalarMergeStrategy.java
@@ -22,14 +22,11 @@ import com.google.common.collect.Lists;
 import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
 import com.torodb.core.transaction.metainf.ImmutableMetaDocPart.Builder;
 import com.torodb.core.transaction.metainf.MetaScalar;
-import com.torodb.metainfo.cache.mvcc.merge.ExecutionResult;
 import com.torodb.metainfo.cache.mvcc.merge.FirstToApplyStrategyPicker;
 import com.torodb.metainfo.cache.mvcc.merge.MergeStrategy;
 import com.torodb.metainfo.cache.mvcc.merge.MergeStrategyPicker;
+import com.torodb.metainfo.cache.mvcc.merge.result.ExecutionResult;
 
-/**
- *
- */
 public class ScalarMergeStrategy implements
     MergeStrategy<ImmutableMetaDocPart, MetaScalar, Builder, ScalarContext> {
 

--- a/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/scalar/ScalarPartialMergeStrategy.java
+++ b/engine/metainfo-cache/src/main/java/com/torodb/metainfo/cache/mvcc/merge/scalar/ScalarPartialMergeStrategy.java
@@ -1,0 +1,38 @@
+/*
+ * ToroDB
+ * Copyright © 2014 8Kdata Technology (www.8kdata.com)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.torodb.metainfo.cache.mvcc.merge.scalar;
+
+
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
+import com.torodb.core.transaction.metainf.ImmutableMetaDocPart.Builder;
+import com.torodb.core.transaction.metainf.MetaScalar;
+import com.torodb.metainfo.cache.mvcc.merge.PartialMergeStrategy;
+
+interface ScalarPartialMergeStrategy
+    extends PartialMergeStrategy<ImmutableMetaDocPart, MetaScalar, Builder, ScalarContext> {
+
+  default MetaScalar getCommitedById(ScalarContext context) {
+    return context.getCommitedParent().getScalar(context.getChanged().getIdentifier());
+  }
+
+  default MetaScalar getCommitedByType(ScalarContext context) {
+    return context.getCommitedParent().getScalar(context.getChanged().getType());
+  }
+
+}

--- a/engine/metainfo-cache/src/test/java/com/torodb/metainfo/cache/mvcc/SnapshotMergerTest.java
+++ b/engine/metainfo-cache/src/test/java/com/torodb/metainfo/cache/mvcc/SnapshotMergerTest.java
@@ -27,8 +27,10 @@ import com.torodb.core.transaction.metainf.ImmutableMetaCollection;
 import com.torodb.core.transaction.metainf.ImmutableMetaDatabase;
 import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
 import com.torodb.core.transaction.metainf.ImmutableMetaField;
+import com.torodb.core.transaction.metainf.ImmutableMetaIndex;
 import com.torodb.core.transaction.metainf.ImmutableMetaScalar;
 import com.torodb.core.transaction.metainf.ImmutableMetaSnapshot;
+import com.torodb.core.transaction.metainf.MutableMetaCollection;
 import com.torodb.core.transaction.metainf.MutableMetaDocPart;
 import com.torodb.core.transaction.metainf.MutableMetaSnapshot;
 import com.torodb.core.transaction.metainf.UnmergeableException;
@@ -40,12 +42,7 @@ import org.junit.Test;
 import org.mockito.MockSettings;
 import org.mockito.internal.creation.MockSettingsImpl;
 
-import java.util.Collections;
 
-/**
- *
- * @author gortiz
- */
 @SuppressWarnings({"unused", "rawtypes"})
 public class SnapshotMergerTest {
 
@@ -69,6 +66,7 @@ public class SnapshotMergerTest {
                     .put(new ImmutableMetaField("fieldName1", "fieldId1", FieldType.INTEGER))
                     .put(new ImmutableMetaScalar("scalarId1", FieldType.INTEGER))
                 )
+                .put(new ImmutableMetaIndex.Builder("idx", true))
                 .build()
             ).build()
         ).build();
@@ -80,16 +78,13 @@ public class SnapshotMergerTest {
   }
 
   /**
-   * Fails if the checker do not allow idempotency
-   *
-   * @throws Exception
+   * Fails if the checker do not allow idempotency.
    */
   @Test
   public void testIdempotency() throws Exception {
     SnapshotMerger merger;
 
-    MutableMetaSnapshot changedSnapshot = new WrapperMutableMetaSnapshot(new ImmutableMetaSnapshot(
-        Collections.emptyMap()));
+    MutableMetaSnapshot changedSnapshot = WrapperMutableMetaSnapshot.createEmpty();
     MutableMetaDocPart metaDocPart = changedSnapshot.addMetaDatabase("dbName1", "dbId1")
         .addMetaCollection("colName1", "colId1")
         .addMetaDocPart(tableRefFactory.createRoot(), "docPartId1");
@@ -101,136 +96,90 @@ public class SnapshotMergerTest {
   }
 
   /**
-   * Test that an exception is thrown on database name conflicts
-   *
-   * @throws Exception
+   * Test that an exception is thrown on database name conflicts.
    */
-  @Test
+  @Test(expected = UnmergeableException.class)
   public void testDatabaseNameConflict() throws Exception {
-    MutableMetaSnapshot changedSnapshot = new WrapperMutableMetaSnapshot(new ImmutableMetaSnapshot(
-        Collections.emptyMap()));
+    MutableMetaSnapshot changedSnapshot = WrapperMutableMetaSnapshot.createEmpty();
     changedSnapshot.addMetaDatabase("dbName2", "dbId1");
 
-    try {
-      new SnapshotMerger(currentSnapshot, changedSnapshot)
-          .merge();
-      Assert.fail("A " + UnmergeableException.class.getSimpleName() + " was expected to be thrown");
-    } catch (UnmergeableException ex) {
-
-    }
+    new SnapshotMerger(currentSnapshot, changedSnapshot)
+        .merge();
   }
 
   /**
-   * Test that an exception is thrown on database id conflicts
-   *
-   * @throws Exception
+   * Test that an exception is thrown on database id conflicts.
    */
-  @Test
+  @Test(expected = UnmergeableException.class)
   public void testDatabaseIdConflict() throws Exception {
-    MutableMetaSnapshot changedSnapshot = new WrapperMutableMetaSnapshot(new ImmutableMetaSnapshot(
-        Collections.emptyMap()));
+    MutableMetaSnapshot changedSnapshot = WrapperMutableMetaSnapshot.createEmpty();
     changedSnapshot.addMetaDatabase("dbName1", "dbId2");
 
-    try {
-      new SnapshotMerger(currentSnapshot, changedSnapshot).merge();
-      Assert.fail("A " + UnmergeableException.class.getSimpleName() + " was expected to be thrown");
-    } catch (UnmergeableException ex) {
-
-    }
+    new SnapshotMerger(currentSnapshot, changedSnapshot)
+        .merge();
   }
 
   /**
-   * Test that an exception is thrown on collection name conflicts
-   *
-   * @throws Exception
+   * Test that an exception is thrown on collection name conflicts.
    */
-  @Test
+  @Test(expected = UnmergeableException.class)
   public void testCollectionNameConflict() throws Exception {
-    MutableMetaSnapshot changedSnapshot = new WrapperMutableMetaSnapshot(new ImmutableMetaSnapshot(
-        Collections.emptyMap()));
+    MutableMetaSnapshot changedSnapshot = WrapperMutableMetaSnapshot.createEmpty();
     changedSnapshot.addMetaDatabase("dbName1", "dbId1")
         .addMetaCollection("colName2", "colId1");
 
-    try {
-      new SnapshotMerger(currentSnapshot, changedSnapshot).merge();
-      Assert.fail("A " + UnmergeableException.class.getSimpleName() + " was expected to be thrown");
-    } catch (UnmergeableException ex) {
-
-    }
+    new SnapshotMerger(currentSnapshot, changedSnapshot)
+        .merge();
   }
 
   /**
-   * Test that an exception is thrown on collection id conflicts
-   *
-   * @throws Exception
+   * Test that an exception is thrown on collection id conflicts.
    */
-  @Test
+  @Test(expected = UnmergeableException.class)
   public void testCollectionIdConflict() throws Exception {
-    MutableMetaSnapshot changedSnapshot = new WrapperMutableMetaSnapshot(new ImmutableMetaSnapshot(
-        Collections.emptyMap()));
+    MutableMetaSnapshot changedSnapshot = WrapperMutableMetaSnapshot.createEmpty();
     changedSnapshot.addMetaDatabase("dbName1", "dbId1")
         .addMetaCollection("colName1", "colId2");
 
-    try {
-      new SnapshotMerger(currentSnapshot, changedSnapshot).merge();
-      Assert.fail("A " + UnmergeableException.class.getSimpleName() + " was expected to be thrown");
-    } catch (UnmergeableException ex) {
-
-    }
+    new SnapshotMerger(currentSnapshot, changedSnapshot)
+        .merge();
   }
 
   /**
-   * Test that an exception is thrown on doc part table ref conflicts
-   *
-   * @throws Exception
+   * Test that an exception is thrown on doc part table ref conflicts.
    */
-  @Test
+  @Test(expected = UnmergeableException.class)
   public void testDocPartRefConflict() throws Exception {
-    MutableMetaSnapshot changedSnapshot = new WrapperMutableMetaSnapshot(new ImmutableMetaSnapshot(
-        Collections.emptyMap()));
+    MutableMetaSnapshot changedSnapshot = WrapperMutableMetaSnapshot.createEmpty();
     changedSnapshot.addMetaDatabase("dbName1", "dbId1")
         .addMetaCollection("colName1", "colId1")
         .addMetaDocPart(tableRefFactory.createChild(tableRefFactory.createRoot(), "anotherTRef"),
             "docPartId1");
 
-    try {
-      new SnapshotMerger(currentSnapshot, changedSnapshot).merge();
-      Assert.fail("A " + UnmergeableException.class.getSimpleName() + " was expected to be thrown");
-    } catch (UnmergeableException ex) {
-
-    }
+    new SnapshotMerger(currentSnapshot, changedSnapshot)
+        .merge();
   }
 
   /**
-   * Test that an exception is thrown on doc part id conflicts
-   *
-   * @throws Exception
+   * Test that an exception is thrown on doc part id conflicts.
    */
-  @Test
+  @Test(expected = UnmergeableException.class)
   public void testDocPartIdConflict() throws Exception {
-    MutableMetaSnapshot changedSnapshot = new WrapperMutableMetaSnapshot(new ImmutableMetaSnapshot(
-        Collections.emptyMap()));
+    MutableMetaSnapshot changedSnapshot = WrapperMutableMetaSnapshot.createEmpty();
     changedSnapshot.addMetaDatabase("dbName1", "dbId1")
         .addMetaCollection("colName1", "colId1")
         .addMetaDocPart(tableRefFactory.createRoot(), "docPartId2");
 
-    try {
-      new SnapshotMerger(currentSnapshot, changedSnapshot).merge();
-      Assert.fail("A " + UnmergeableException.class.getSimpleName() + " was expected to be thrown");
-    } catch (UnmergeableException ex) {
-
-    }
+    new SnapshotMerger(currentSnapshot, changedSnapshot)
+        .merge();
   }
 
   /**
-   * Test that an exception is thrown on field name and type conflicts
-   *
-   * @throws Exception
+   * Test that an exception is thrown on field name and type conflicts.
    */
   @Test
   public void testFieldNameAndTypeConflict() throws Exception {
-    MutableMetaSnapshot changedSnapshot = new WrapperMutableMetaSnapshot(new ImmutableMetaSnapshot(
-        Collections.emptyMap()));
+    MutableMetaSnapshot changedSnapshot = WrapperMutableMetaSnapshot.createEmpty();
     changedSnapshot.addMetaDatabase("dbName1", "dbId1")
         .addMetaCollection("colName1", "colId1")
         .addMetaDocPart(tableRefFactory.createRoot(), "docPartId1")
@@ -243,8 +192,7 @@ public class SnapshotMergerTest {
 
     }
 
-    changedSnapshot = new WrapperMutableMetaSnapshot(new ImmutableMetaSnapshot(Collections
-        .emptyMap()));
+    changedSnapshot = WrapperMutableMetaSnapshot.createEmpty();
     changedSnapshot.addMetaDatabase("dbName1", "dbId1")
         .addMetaCollection("colName1", "colId1")
         .addMetaDocPart(tableRefFactory.createRoot(), "docPartId1")
@@ -259,37 +207,27 @@ public class SnapshotMergerTest {
   }
 
   /**
-   * Test that an exception is thrown on field id conflicts
-   *
-   * @throws Exception
+   * Test that an exception is thrown on field id conflicts.
    */
-  @Test
+  @Test(expected = UnmergeableException.class)
   public void testFieldIdConflict() throws Exception {
-    MutableMetaSnapshot changedSnapshot = new WrapperMutableMetaSnapshot(new ImmutableMetaSnapshot(
-        Collections.emptyMap()));
+    MutableMetaSnapshot changedSnapshot = WrapperMutableMetaSnapshot.createEmpty();
     changedSnapshot.addMetaDatabase("dbName1", "dbId1")
         .addMetaCollection("colName1", "colId1")
         .addMetaDocPart(tableRefFactory.createRoot(), "docPartId1")
         .addMetaField("fieldName1", "fieldId2", FieldType.INTEGER);
 
-    try {
-      new SnapshotMerger(currentSnapshot, changedSnapshot).merge();
-      Assert.fail("A " + UnmergeableException.class.getSimpleName() + " was expected to be thrown");
-    } catch (UnmergeableException ex) {
-
-    }
+    new SnapshotMerger(currentSnapshot, changedSnapshot)
+        .merge();
   }
 
   /**
    * Test that no exception is thrown when creating a new field that shares type but not name with a
    * previous one.
-   *
-   * @throws Exception
    */
   @Test
   public void testField_differentName() throws Exception {
-    MutableMetaSnapshot changedSnapshot = new WrapperMutableMetaSnapshot(new ImmutableMetaSnapshot(
-        Collections.emptyMap()));
+    MutableMetaSnapshot changedSnapshot = WrapperMutableMetaSnapshot.createEmpty();
     changedSnapshot.addMetaDatabase("dbName1", "dbId1")
         .addMetaCollection("colName1", "colId1")
         .addMetaDocPart(tableRefFactory.createRoot(), "docPartId1")
@@ -301,13 +239,10 @@ public class SnapshotMergerTest {
   /**
    * Test that no exception is thrown when creating a new field that shares name but not type with a
    * previous one.
-   *
-   * @throws Exception
    */
   @Test
   public void testField_differentType() throws Exception {
-    MutableMetaSnapshot changedSnapshot = new WrapperMutableMetaSnapshot(new ImmutableMetaSnapshot(
-        Collections.emptyMap()));
+    MutableMetaSnapshot changedSnapshot = WrapperMutableMetaSnapshot.createEmpty();
     changedSnapshot.addMetaDatabase("dbName1", "dbId1")
         .addMetaCollection("colName1", "colId1")
         .addMetaDocPart(tableRefFactory.createRoot(), "docPartId1")
@@ -317,14 +252,11 @@ public class SnapshotMergerTest {
   }
 
   /**
-   * Test that no exception is thrown when creating a new field with different id, name and type
-   *
-   * @throws Exception
+   * Test that no exception is thrown when creating a new field with different id, name and type.
    */
   @Test
   public void testField_different() throws Exception {
-    MutableMetaSnapshot changedSnapshot = new WrapperMutableMetaSnapshot(new ImmutableMetaSnapshot(
-        Collections.emptyMap()));
+    MutableMetaSnapshot changedSnapshot = WrapperMutableMetaSnapshot.createEmpty();
     changedSnapshot.addMetaDatabase("dbName1", "dbId1")
         .addMetaCollection("colName1", "colId1")
         .addMetaDocPart(tableRefFactory.createRoot(), "docPartId1")
@@ -334,63 +266,61 @@ public class SnapshotMergerTest {
   }
 
   /**
-   * Test that an exception is thrown on scalar id conflicts
-   *
-   * @throws Exception
+   * Test that an exception is thrown on scalar id conflicts.
    */
-  @Test
+  @Test(expected = UnmergeableException.class)
   public void testScalarIdConflict() throws Exception {
-    MutableMetaSnapshot changedSnapshot = new WrapperMutableMetaSnapshot(new ImmutableMetaSnapshot(
-        Collections.emptyMap()));
+    MutableMetaSnapshot changedSnapshot = WrapperMutableMetaSnapshot.createEmpty();
     changedSnapshot.addMetaDatabase("dbName1", "dbId1")
         .addMetaCollection("colName1", "colId1")
         .addMetaDocPart(tableRefFactory.createRoot(), "docPartId1")
         .addMetaScalar("scalarId1", FieldType.LONG);
 
-    try {
-      new SnapshotMerger(currentSnapshot, changedSnapshot).merge();
-      Assert.fail("A " + UnmergeableException.class.getSimpleName() + " was expected to be thrown");
-    } catch (UnmergeableException ex) {
-
-    }
+    new SnapshotMerger(currentSnapshot, changedSnapshot)
+        .merge();
   }
 
   /**
-   * Test that an exception is thrown on scalar type conflicts
-   *
-   * @throws Exception
+   * Test that an exception is thrown on scalar type conflicts.
    */
-  @Test
+  @Test(expected = UnmergeableException.class)
   public void testScalarTypeConflict() throws Exception {
-    MutableMetaSnapshot changedSnapshot = new WrapperMutableMetaSnapshot(new ImmutableMetaSnapshot(
-        Collections.emptyMap()));
+    MutableMetaSnapshot changedSnapshot = WrapperMutableMetaSnapshot.createEmpty();
     changedSnapshot.addMetaDatabase("dbName1", "dbId1")
         .addMetaCollection("colName1", "colId1")
         .addMetaDocPart(tableRefFactory.createRoot(), "docPartId1")
         .addMetaScalar("fieldId2", FieldType.INTEGER);
 
-    try {
-      new SnapshotMerger(currentSnapshot, changedSnapshot).merge();
-      Assert.fail("A " + UnmergeableException.class.getSimpleName() + " was expected to be thrown");
-    } catch (UnmergeableException ex) {
-
-    }
+    new SnapshotMerger(currentSnapshot, changedSnapshot)
+        .merge();
   }
 
   /**
-   * Test that no exception is thrown when creating a new scalar with different id and type
-   *
-   * @throws Exception
+   * Test that no exception is thrown when creating a new scalar with different id and type.
    */
   @Test
   public void testScalar_different() throws Exception {
-    MutableMetaSnapshot changedSnapshot = new WrapperMutableMetaSnapshot(new ImmutableMetaSnapshot(
-        Collections.emptyMap()));
+    MutableMetaSnapshot changedSnapshot = WrapperMutableMetaSnapshot.createEmpty();
     changedSnapshot.addMetaDatabase("dbName1", "dbId1")
         .addMetaCollection("colName1", "colId1")
         .addMetaDocPart(tableRefFactory.createRoot(), "docPartId1")
         .addMetaScalar("fieldId20", FieldType.LONG);
 
+    new SnapshotMerger(currentSnapshot, changedSnapshot).merge();
+  }
+
+  @Test
+  public void testIndex_dropAndCreate() {
+    //GIVEN
+    MutableMetaSnapshot changedSnapshot = new WrapperMutableMetaSnapshot(currentSnapshot);
+    MutableMetaCollection col = changedSnapshot.getMetaDatabaseByIdentifier("dbId1")
+            .getMetaCollectionByIdentifier("colId1");
+
+    //WHEN
+    col.removeMetaIndexByName("idx");
+    col.addMetaIndex("idx", true);
+
+    //THEN
     new SnapshotMerger(currentSnapshot, changedSnapshot).merge();
   }
 }

--- a/engine/mongodb/mongodb-core/src/main/java/com/torodb/mongodb/commands/impl/WriteTransactionCmdImpl.java
+++ b/engine/mongodb/mongodb-core/src/main/java/com/torodb/mongodb/commands/impl/WriteTransactionCmdImpl.java
@@ -25,6 +25,7 @@ import com.torodb.core.annotations.DoNotChange;
 import com.torodb.core.logging.LoggerFactory;
 import com.torodb.mongodb.commands.CmdImplMapSupplier;
 import com.torodb.mongodb.commands.impl.admin.CreateCollectionImplementation;
+import com.torodb.mongodb.commands.impl.admin.CreateIndexesImplementation;
 import com.torodb.mongodb.commands.impl.admin.DropCollectionImplementation;
 import com.torodb.mongodb.commands.impl.admin.DropDatabaseImplementation;
 import com.torodb.mongodb.commands.impl.admin.DropIndexesImplementation;
@@ -32,6 +33,7 @@ import com.torodb.mongodb.commands.impl.general.DeleteImplementation;
 import com.torodb.mongodb.commands.impl.general.InsertImplementation;
 import com.torodb.mongodb.commands.impl.general.UpdateImplementation;
 import com.torodb.mongodb.commands.signatures.admin.CreateCollectionCommand;
+import com.torodb.mongodb.commands.signatures.admin.CreateIndexesCommand;
 import com.torodb.mongodb.commands.signatures.admin.DropCollectionCommand;
 import com.torodb.mongodb.commands.signatures.admin.DropDatabaseCommand;
 import com.torodb.mongodb.commands.signatures.admin.DropIndexesCommand;
@@ -57,6 +59,7 @@ public class WriteTransactionCmdImpl implements CmdImplMapSupplier<WriteMongodTr
         .put(DropDatabaseCommand.INSTANCE, new DropDatabaseImplementation(loggerFactory))
         .put(DropCollectionCommand.INSTANCE, new DropCollectionImplementation(loggerFactory))
         .put(CreateCollectionCommand.INSTANCE, new CreateCollectionImplementation())
+        .put(CreateIndexesCommand.INSTANCE, new CreateIndexesImplementation())
         .put(DropIndexesCommand.INSTANCE, new DropIndexesImplementation())
         .put(InsertCommand.INSTANCE, new InsertImplementation())
         .put(DeleteCommand.INSTANCE, new DeleteImplementation(loggerFactory))

--- a/engine/mongodb/mongodb-core/src/main/java/com/torodb/mongodb/commands/impl/admin/DropCollectionImplementation.java
+++ b/engine/mongodb/mongodb-core/src/main/java/com/torodb/mongodb/commands/impl/admin/DropCollectionImplementation.java
@@ -47,7 +47,7 @@ public class DropCollectionImplementation implements
       Command<? super CollectionCommandArgument, ? super Empty> command,
       CollectionCommandArgument arg, WriteMongodTransaction context) {
     try {
-      logDropCommand(arg);
+      logDropCommand(req, arg);
 
       context.getTorodTransaction().dropCollection(req.getDatabase(), arg.getCollection());
     } catch (UserException ex) {
@@ -58,10 +58,10 @@ public class DropCollectionImplementation implements
     return Status.ok();
   }
 
-  private void logDropCommand(CollectionCommandArgument arg) {
+  private void logDropCommand(Request req, CollectionCommandArgument arg) {
     String collection = arg.getCollection();
 
-    logger.info("Drop collection {}", collection);
+    logger.info("Drop collection {}.{}", req.getDatabase(), collection);
   }
 
 }

--- a/engine/mongodb/mongodb-core/src/main/java/com/torodb/mongodb/utils/cloner/AkkaDbCloner.java
+++ b/engine/mongodb/mongodb-core/src/main/java/com/torodb/mongodb/utils/cloner/AkkaDbCloner.java
@@ -242,8 +242,8 @@ public class AkkaDbCloner extends ActorSystemTorodbService implements DbCloner {
     }
   }
 
-  private void cloneIndexes(List<Entry> collsToClone, MongoConnection remoteConnection, String dstDb,
-      MongodServer localServer, CloneOptions opts) {
+  private void cloneIndexes(List<Entry> collsToClone, MongoConnection remoteConnection, 
+      String dstDb, MongodServer localServer, CloneOptions opts) {
     String fromDb = opts.getDbToClone();
     for (Entry entry : collsToClone) {
       logger.info("Cloning collection indexes {}.{} into {}.{}",

--- a/engine/mongodb/sharding/src/main/java/com/torodb/engine/mongodb/sharding/isolation/db/DbIsolatorServer.java
+++ b/engine/mongodb/sharding/src/main/java/com/torodb/engine/mongodb/sharding/isolation/db/DbIsolatorServer.java
@@ -18,12 +18,14 @@
 
 package com.torodb.engine.mongodb.sharding.isolation.db;
 
+import com.torodb.common.util.Empty;
 import com.torodb.core.logging.LoggerFactory;
 import com.torodb.core.services.IdleTorodbService;
 import com.torodb.torod.TorodConnection;
 import com.torodb.torod.TorodServer;
 import org.apache.logging.log4j.Logger;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadFactory;
 
 
@@ -60,13 +62,13 @@ public class DbIsolatorServer extends IdleTorodbService implements TorodServer {
   }
 
   @Override
-  public void disableDataImportMode() {
-    logger.warn("Data import mode is ignored on isolated databases");
+  public CompletableFuture<Empty> disableDataImportMode(String dbName) {
+    return decorated.disableDataImportMode(convertDatabaseName(dbName));
   }
 
   @Override
-  public void enableDataImportMode() {
-    logger.warn("Data import mode is ignored on isolated databases");
+  public CompletableFuture<Empty> enableDataImportMode(String dbName) {
+    return decorated.enableDataImportMode(convertDatabaseName(dbName));
   }
 
   @Override

--- a/engine/torod/src/main/java/com/torodb/torod/TorodServer.java
+++ b/engine/torod/src/main/java/com/torodb/torod/TorodServer.java
@@ -18,7 +18,10 @@
 
 package com.torodb.torod;
 
+import com.torodb.common.util.Empty;
 import com.torodb.core.services.TorodbService;
+
+import java.util.concurrent.CompletableFuture;
 
 /**
  *
@@ -27,7 +30,7 @@ public interface TorodServer extends TorodbService {
 
   public TorodConnection openConnection();
 
-  public void disableDataImportMode();
+  public CompletableFuture<Empty> disableDataImportMode(String dbName);
 
-  public void enableDataImportMode();
+  public CompletableFuture<Empty> enableDataImportMode(String dbName);
 }

--- a/engine/torod/src/main/java/com/torodb/torod/impl/memory/MemoryTorodServer.java
+++ b/engine/torod/src/main/java/com/torodb/torod/impl/memory/MemoryTorodServer.java
@@ -22,10 +22,12 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalNotification;
 import com.google.inject.Singleton;
+import com.torodb.common.util.Empty;
 import com.torodb.core.services.IdleTorodbService;
 import com.torodb.torod.TorodConnection;
 import com.torodb.torod.TorodServer;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -57,11 +59,13 @@ public class MemoryTorodServer extends IdleTorodbService implements TorodServer 
   }
 
   @Override
-  public void disableDataImportMode() {
+  public CompletableFuture<Empty> disableDataImportMode(String dbName) {
+    return CompletableFuture.completedFuture(Empty.getInstance());
   }
 
   @Override
-  public void enableDataImportMode() {
+  public CompletableFuture<Empty> enableDataImportMode(String dbName) {
+    return CompletableFuture.completedFuture(Empty.getInstance());
   }
 
   @Override

--- a/engine/torod/src/main/java/com/torodb/torod/impl/sql/SqlTorodTransaction.java
+++ b/engine/torod/src/main/java/com/torodb/torod/impl/sql/SqlTorodTransaction.java
@@ -386,7 +386,7 @@ public abstract class SqlTorodTransaction<T extends InternalTransaction>
     metaIndex.iteratorFields()
         .forEachRemaining(metaIndexField ->
             indexInfoBuilder.addField(
-                getAttrivuteReference(metaIndexField.getTableRef(), metaIndexField.getName()),
+                getAttrivuteReference(metaIndexField.getTableRef(), metaIndexField.getFieldName()),
                 metaIndexField.getOrdering().isAscending()));
 
     return indexInfoBuilder.build();

--- a/engine/torod/src/main/java/com/torodb/torod/impl/sql/SqlWriteTorodTransaction.java
+++ b/engine/torod/src/main/java/com/torodb/torod/impl/sql/SqlWriteTorodTransaction.java
@@ -224,7 +224,7 @@ public abstract class SqlWriteTorodTransaction<T extends WriteInternalTransactio
               Tuple3<TableRef, String, FieldIndexOrdering> indexFieldDef =
                   indexFieldDefs.get(indexField.getPosition());
               return indexFieldDef != null && indexFieldDef.v1().equals(indexField.getTableRef())
-                  && indexFieldDef.v2().equals(indexField.getName()) && indexFieldDef.v3()
+                  && indexFieldDef.v2().equals(indexField.getFieldName()) && indexFieldDef.v3()
                   == indexField.getOrdering();
             })));
 

--- a/engine/torod/src/main/java/com/torodb/torod/pipeline/BatchMetaDocPart.java
+++ b/engine/torod/src/main/java/com/torodb/torod/pipeline/BatchMetaDocPart.java
@@ -20,19 +20,18 @@ package com.torodb.torod.pipeline;
 
 import com.torodb.core.TableRef;
 import com.torodb.core.annotations.DoNotChange;
+import com.torodb.core.transaction.metainf.ChangedElement;
 import com.torodb.core.transaction.metainf.FieldType;
 import com.torodb.core.transaction.metainf.ImmutableMetaDocPart;
 import com.torodb.core.transaction.metainf.ImmutableMetaField;
 import com.torodb.core.transaction.metainf.ImmutableMetaIdentifiedDocPartIndex;
 import com.torodb.core.transaction.metainf.ImmutableMetaScalar;
-import com.torodb.core.transaction.metainf.MetaElementState;
 import com.torodb.core.transaction.metainf.MetaField;
 import com.torodb.core.transaction.metainf.MetaIdentifiedDocPartIndex;
 import com.torodb.core.transaction.metainf.MetaIndex;
 import com.torodb.core.transaction.metainf.MetaScalar;
 import com.torodb.core.transaction.metainf.MutableMetaDocPart;
 import com.torodb.core.transaction.metainf.MutableMetaDocPartIndex;
-import org.jooq.lambda.tuple.Tuple2;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -124,8 +123,8 @@ public class BatchMetaDocPart implements MutableMetaDocPart {
   }
 
   @Override
-  public Iterable<? extends ImmutableMetaField> getAddedMetaFields() {
-    return delegate.getAddedMetaFields();
+  public Stream<? extends ImmutableMetaField> streamAddedMetaFields() {
+    return delegate.streamAddedMetaFields();
   }
 
   @Override
@@ -149,8 +148,8 @@ public class BatchMetaDocPart implements MutableMetaDocPart {
   }
 
   @Override
-  public Iterable<? extends ImmutableMetaScalar> getAddedMetaScalars() {
-    return delegate.getAddedMetaScalars();
+  public Stream<? extends ImmutableMetaScalar> streamAddedMetaScalars() {
+    return delegate.streamAddedMetaScalars();
   }
 
   @Override
@@ -176,8 +175,8 @@ public class BatchMetaDocPart implements MutableMetaDocPart {
 
   @Override
   @SuppressWarnings("checkstyle:LineLength")
-  public Iterable<Tuple2<ImmutableMetaIdentifiedDocPartIndex, MetaElementState>> getModifiedMetaDocPartIndexes() {
-    return delegate.getModifiedMetaDocPartIndexes();
+  public Stream<ChangedElement<ImmutableMetaIdentifiedDocPartIndex>> streamModifiedMetaDocPartIndexes() {
+    return delegate.streamModifiedMetaDocPartIndexes();
   }
 
   @Override

--- a/engine/torod/src/test/java/com/torodb/torod/pipeline/BatchMetaDocPartTest.java
+++ b/engine/torod/src/test/java/com/torodb/torod/pipeline/BatchMetaDocPartTest.java
@@ -110,8 +110,8 @@ public class BatchMetaDocPartTest {
     assertNotNull(docPart.getMetaFieldByIdentifier(fieldId));
     assertNotNull(docPart.getMetaFieldByNameAndType(fieldName, fieldType));
 
-    assertFalse(Iterables.isEmpty(docPart.getAddedMetaFields()));
-    assertFalse(Iterables.isEmpty(delegate.getAddedMetaFields()));
+    assertFalse(!docPart.streamAddedMetaFields().findAny().isPresent());
+    assertFalse(!delegate.streamAddedMetaFields().findAny().isPresent());
     assertFalse(Iterables.isEmpty(docPart.getOnBatchModifiedMetaFields()));
 
     verify(testChangeConsumer).accept(docPart);

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
     <properties>
         <torodb.engine.version>0.50.1-SNAPSHOT</torodb.engine.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <log4j.version>2.7</log4j.version>
         <jackson.version>2.6.3</jackson.version>
         <mongowp.version>0.50.1-SNAPSHOT</mongowp.version>

--- a/stampede/main/src/main/profiles/dev/log4j2.xml
+++ b/stampede/main/src/main/profiles/dev/log4j2.xml
@@ -31,6 +31,10 @@
             <AppenderRef ref="ASYNC"/>
         </Logger>
         
+        <Logger name="com.torodb.mongodb.repl.topology" level="DEBUG" additivity="false">
+            <AppenderRef ref="ASYNC"/>
+        </Logger>
+        
         <Logger name="com.torodb.core.retrier" level="TRACE" additivity="false">
             <AppenderRef ref="ASYNC"/>
         </Logger>


### PR DESCRIPTION
Changed import mode feature to be able to change the mode by mongo database (instead of sql database). By doing that, each replication shard can enable/disable the import mode on their databases.

This feature exposed a bug on the snapshot merger that failed when an index is deleted and created on the same transaction. To be able to fix that, the merger has been split into several merged strategies, so it should be easier to understand what it does and extend it. Once it has been split, two new strategies have been added. They automatically accept a merge on database and collections if the original database/collection is the same as the last commited one.